### PR TITLE
docs: pitch-focused README with falsifiability manifesto

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,19 +2,16 @@
 
 # buildlog
 
-### Engineering Notebook for AI-Assisted Development
+### The Only Agent Learning System You Can Prove Works
 
 [![PyPI](https://img.shields.io/pypi/v/buildlog?style=for-the-badge&logo=pypi&logoColor=white)](https://pypi.org/project/buildlog/)
 [![Python](https://img.shields.io/pypi/pyversions/buildlog?style=for-the-badge&logo=python&logoColor=white)](https://python.org/)
 [![CI](https://img.shields.io/github/actions/workflow/status/Peleke/buildlog-template/ci.yml?branch=main&style=for-the-badge&logo=github&label=CI)](https://github.com/Peleke/buildlog-template/actions/workflows/ci.yml)
-[![Coverage](https://img.shields.io/codecov/c/github/Peleke/buildlog-template?style=for-the-badge&logo=codecov&logoColor=white)](https://codecov.io/gh/Peleke/buildlog-template)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=for-the-badge)](https://opensource.org/licenses/MIT)
 
-**Capture your work as publishable content. Include the fuckups.**
+**Falsifiable claims. Measurable outcomes. No vibes.**
 
-<img src="assets/hero-notebook.png" alt="buildlog - Engineering Notebook for AI-Assisted Development" width="800"/>
-
-[Quick Start](#-quick-start) · [The Pipeline](#-the-pipeline) · [Commands](#-commands) · [Philosophy](#-philosophy)
+[The Problem](#the-problem) · [The Claim](#the-claim) · [The Mechanism](#the-mechanism) · [Quick Start](#quick-start)
 
 ---
 
@@ -22,65 +19,186 @@
 
 ## The Problem
 
-You're pairing with AI on real work. Hours of debugging, wrong turns, "oh shit" moments, and hard-won insights—all vanishing into chat history the moment you close the tab.
+Everyone's building "agent memory." Blog posts announce breakthroughs. Tweets show impressive demos. Products ship with "learning" in the tagline.
 
-Meanwhile, your AI agent makes the same mistakes on similar problems because it has no memory of what you learned together.
+Ask them one question: **How do you know it works?**
 
-## The Solution
+You'll get:
+- "It feels smarter"
+- "Users report better results"
+- "The agent remembers things now"
 
-**buildlog** captures the signal from AI-assisted development sessions and transforms it into:
+That's not evidence. That's vibes.
 
-1. **Publishable content** - Each entry is a $500+ tutorial draft
-2. **Structured insights** - Categorized learnings ready for analysis
-3. **Agent rules** - Deduplicated, confidence-scored rules that improve AI behavior
+Here's what a real answer looks like:
+
+> "We track Repeated Mistake Rate (RMR) across sessions. Our null hypothesis is that the system makes no difference. After 50 sessions, RMR decreased from 34% to 12% (p < 0.01). The effect size is 0.65. Here's the data."
+
+If you can't say something like that, you don't have agent learning. You have a demo.
+
+---
+
+## The Claim
+
+**buildlog** makes a falsifiable claim:
+
+> **H₀ (Null Hypothesis):** buildlog makes no measurable difference to agent behavior.
+>
+> **H₁ (Alternative):** Agents using buildlog-learned rules have lower Repeated Mistake Rate than baseline.
+
+We provide the infrastructure to **reject or fail to reject** this hypothesis with your own data.
+
+If buildlog doesn't work, the numbers will show it. That's the point.
+
+---
+
+## The Metric: Repeated Mistake Rate (RMR)
+
+```
+RMR = (Mistakes that match previous mistakes) / (Total mistakes logged)
+```
+
+A mistake "matches" if it has the same semantic signature—same error class, similar description, same root cause showing up again.
+
+**Why RMR?**
+- **Observable**: You can count it
+- **Attributable**: Lower RMR after rule injection = signal
+- **Meaningful**: Repeating mistakes is the actual pain point
+
+RMR is not the only metric that matters. But it's one we can measure, and measurement is where science starts.
+
+---
+
+## The Mechanism
+
+buildlog uses **contextual bandits** to select which rules to surface.
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    CONTEXTUAL BANDIT SETUP                      │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                 │
+│  Context (c):     Error class, file type, task category        │
+│  Arms (a):        Candidate rules to surface                   │
+│  Reward (r):      Human feedback (👍 helpful / 👎 not helpful) │
+│                                                                 │
+│  Policy π(c) → a:  Thompson Sampling with Beta-Bernoulli       │
+│                                                                 │
+│  Objective:       Minimize regret = Σ(r* - r_chosen)           │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+**Arms** = learned rules (from buildlog entries, code reviews, explicit teaching)
+
+**Context** = what kind of problem you're working on
+
+**Reward** = did surfacing this rule actually help?
+
+The system explores (tries uncertain rules) and exploits (uses proven rules) based on accumulated evidence. Thompson Sampling provides theoretical guarantees: O(√(KT log K)) regret bounds.
+
+This isn't magic. It's a well-understood framework with decades of research. We're applying it to agent rule selection.
+
+---
+
+## The Pipeline
+
+buildlog captures signal at every stage:
 
 ```mermaid
 flowchart LR
-    A["Raw Sessions<br/>(ephemeral)"] --> B["Buildlog Entries<br/>(structured markdown)"]
-    B --> C["Distilled Insights<br/>(categorized patterns)"]
-    C --> D["Agent Rules<br/>(deduplicated + scored)"]
-    D --> E["CLAUDE.md<br/>settings.json<br/>Agent Skills"]
+    A["Work Sessions"] --> B["Structured Entries"]
+    B --> C["Extracted Rules"]
+    C --> D["Bandit Selection"]
+    D --> E["Rule Surfaced"]
+    E --> F["Human Feedback"]
+    F --> G["Posterior Update"]
+    G --> D
 
-    style A fill:#ff6b6b,color:#fff
-    style B fill:#4ecdc4,color:#fff
-    style C fill:#45b7d1,color:#fff
-    style D fill:#96ceb4,color:#fff
-    style E fill:#dda0dd,color:#fff
+    style F fill:#ff6b6b,color:#fff
+    style G fill:#4ecdc4,color:#fff
+```
+
+### Stage 1: Capture
+Document your work. Include the fuckups—they're the most valuable signal.
+
+```bash
+buildlog new auth-api
+# Edit the markdown, document what happened
+```
+
+### Stage 2: Extract
+Pull structured rules from your entries.
+
+```bash
+buildlog distill    # Extract patterns
+buildlog skills     # Deduplicate into rules
+```
+
+### Stage 3: Promote
+Surface rules to your agent via CLAUDE.md, settings.json, or Agent Skills.
+
+```bash
+buildlog promote --target skill
+```
+
+### Stage 4: Measure
+Track what happens when rules are active.
+
+```bash
+buildlog experiment start --error-class "type-errors"
+# ... work session ...
+buildlog experiment log-mistake --error-class "type-errors" \
+  --description "Forgot to handle null case"
+buildlog experiment end
+buildlog experiment report
+```
+
+### Stage 5: Learn
+Log reward signals when rules help (or don't).
+
+```python
+# Via MCP
+buildlog_log_reward(
+    skill_id="arch-123",
+    reward=1,           # 1 = helped, 0 = didn't help
+    context="type-errors",
+    outcome="Caught the bug before commit"
+)
 ```
 
 ---
 
-## Key Concepts
+## Experiment Infrastructure
 
-| Term | What it means |
-|------|---------------|
-| **Entry** | A structured markdown file documenting one work session |
-| **Insight** | A single learning extracted from an entry's Improvements section |
-| **Pattern** | Raw insights grouped by category (architectural, workflow, etc.) |
-| **Rule** | Deduplicated insight with stable ID, confidence score, and source tracking |
-| **Agent Skill** | Rules promoted to `.claude/skills/` for on-demand loading by Claude |
+buildlog ships with infrastructure to run actual experiments:
 
----
+```bash
+# Start a tracked session
+buildlog experiment start --error-class "api-design"
 
-## Features
+# Log mistakes as they happen
+buildlog experiment log-mistake \
+  --error-class "api-design" \
+  --description "Returned 200 for error case"
 
-### Structured Capture
-Templates with six required sections ensure you never forget to document the mistakes that teach the most.
+# End session
+buildlog experiment end
 
-### Pattern Distillation
-Extract categorized insights from all your entries into structured JSON/YAML for analysis.
+# Get metrics
+buildlog experiment metrics
 
-### Semantic Deduplication
-"Run tests before commit" and "Always execute the test suite prior to committing" are the same insight. buildlog merges them.
+# Full report across all sessions
+buildlog experiment report
+```
 
-### Confidence Scoring
-Rules are scored based on frequency and recency. High-confidence rules have been reinforced multiple times recently.
+The report includes:
+- Total sessions, total mistakes
+- Repeat rate (RMR)
+- Mistakes by error class
+- Rules that correlate with corrections
 
-### Multiple Promotion Targets
-Promote rules to CLAUDE.md, settings.json, or **Anthropic Agent Skills** (`.claude/skills/`) for on-demand loading.
-
-### Pluggable Embeddings
-Token-based similarity by default. Upgrade to sentence-transformers or OpenAI for semantic understanding.
+This is the data you need to make claims.
 
 ---
 
@@ -90,756 +208,157 @@ Token-based similarity by default. Upgrade to sentence-transformers or OpenAI fo
 # Install
 pip install buildlog
 
-# Initialize in your project
+# Initialize
 buildlog init
 
-# Create an entry for today's work
-buildlog new auth-api
+# Create your first entry
+buildlog new my-feature
 
-# After a few entries, extract patterns
+# After a few entries, extract rules
 buildlog distill
-
-# Generate deduplicated rules
 buildlog skills
+
+# Start measuring
+buildlog experiment start
+# ... work ...
+buildlog experiment end
+buildlog experiment report
 ```
 
----
-
-## The Pipeline
-
-buildlog is a three-stage pipeline that transforms ephemeral work into durable knowledge:
-
-```mermaid
-flowchart TB
-    subgraph Stage1["Stage 1: Capture"]
-        A1["buildlog new slug"] --> A2["Edit markdown entry"]
-        A2 --> A3["Document: Goal, Journey,<br/>Tests, Code, Improvements"]
-    end
-
-    subgraph Stage2["Stage 2: Distill"]
-        B1["buildlog distill"] --> B2["Parse all entries"]
-        B2 --> B3["Extract Improvements sections"]
-        B3 --> B4["Group by category"]
-    end
-
-    subgraph Stage3["Stage 3: Promote"]
-        C1["buildlog skills"] --> C2["Deduplicate similar insights"]
-        C2 --> C3["Calculate confidence scores"]
-        C3 --> C4["Generate stable IDs"]
-        C4 --> C5["Promote to target"]
-    end
-
-    Stage1 --> Stage2 --> Stage3
-
-    C5 --> D1["CLAUDE.md"]
-    C5 --> D2["settings.json"]
-    C5 --> D3[".claude/skills/"]
-```
-
-### Stage 1: Capture (`buildlog new`)
-
-Create structured entries as you work. Each entry has six sections:
-
-| Section | Purpose |
-|---------|---------|
-| **The Goal** | What you're building and why |
-| **What We Built** | Architecture diagram, components |
-| **The Journey** | Chronological narrative *including mistakes* |
-| **Test Results** | Actual commands, actual outputs |
-| **Code Samples** | Key snippets with context |
-| **Improvements** | Categorized learnings for next time |
-
-The **Improvements** section is structured for machine extraction:
-
-```markdown
-### Architectural
-- Always validate inputs at the boundary, not conditionally
-- Use frozen dataclasses for immutable data containers
-
-### Workflow
-- Run the test suite after EVERY code change, not just at the end
-- Write the integration test first to clarify the API contract
-
-### Tool Usage
-- The `patch` context manager for date mocking is cleaner than fixtures
-- Use `jwt.io` to decode tokens instead of console.log
-
-### Domain Knowledge
-- `datetime.utcnow()` is deprecated in Python 3.12+
-- Supabase storage returns 400, not 404, for missing files
-```
-
-### Stage 2: Distill (`buildlog distill`)
-
-Extract all insights across entries into structured data:
+### MCP Server (Claude Code Integration)
 
 ```bash
-buildlog distill                    # JSON to stdout
-buildlog distill -o patterns.yaml   # Write to file
-buildlog distill --since 2026-01-01 # Filter by date
-buildlog distill --category workflow # Filter by category
+pip install buildlog[mcp]
 ```
 
-Output:
+Add to `~/.claude/settings.json`:
+
 ```json
 {
-  "patterns": {
-    "architectural": [
-      {"insight": "Always validate inputs at boundary...", "source": "2026-01-16-auth.md"}
-    ],
-    "workflow": [...],
-    "tool_usage": [...],
-    "domain_knowledge": [...]
-  },
-  "statistics": {
-    "total_patterns": 47,
-    "by_category": {"architectural": 12, "workflow": 15, ...}
+  "mcpServers": {
+    "buildlog": {
+      "command": "buildlog-mcp"
+    }
   }
 }
 ```
 
-### Stage 3: Generate Rules (`buildlog skills`)
-
-Transform raw patterns into deduplicated, scored rules:
-
-```bash
-buildlog skills                           # YAML to stdout
-buildlog skills -o rules.yml              # Write to file
-buildlog skills --format markdown         # For CLAUDE.md injection
-buildlog skills --min-frequency 2         # Only repeated patterns
-buildlog skills --embeddings openai       # Semantic deduplication
-```
-
-Output:
-```yaml
-generated_at: '2026-01-16T12:00:00Z'
-source_entries: 23
-total_skills: 31
-skills:
-  architectural:
-    - id: arch-b0fcb62a1e
-      rule: Always validate inputs at the boundary, not conditionally
-      frequency: 4
-      confidence: high
-      sources: [auth.md, api.md, validation.md, forms.md]
-      tags: [api, error]
-    - id: arch-0cda924aeb
-      rule: Frozen dataclasses should be the default for data containers
-      frequency: 2
-      confidence: medium
-      sources: [models.md, dto.md]
-      tags: [python]
-```
+Available tools:
+| Tool | Purpose |
+|------|---------|
+| `buildlog_status` | View rules by category and confidence |
+| `buildlog_promote` | Surface rules to agent |
+| `buildlog_reject` | Mark false positives |
+| `buildlog_diff` | Rules pending review |
+| `buildlog_learn_from_review` | Extract rules from code review |
+| `buildlog_log_reward` | Record reward signal for bandit |
+| `buildlog_rewards` | View reward history |
+| `buildlog_start_session` | Begin tracked experiment session |
+| `buildlog_end_session` | End session |
+| `buildlog_log_mistake` | Record mistake during session |
+| `buildlog_session_metrics` | Get session statistics |
+| `buildlog_experiment_report` | Full experiment report |
 
 ---
 
-## Patterns vs Rules
+## What This Is Not
 
-**Patterns** are raw extractions—every insight from every entry, exactly as written.
+**This is not AGI.** This is not "agents that truly learn." This is not a revolution.
 
-**Rules** are processed patterns with:
+This is:
+- A structured way to capture engineering knowledge
+- A bandit framework for rule selection
+- Infrastructure to measure whether it works
 
-| Property | Description |
-|----------|-------------|
-| **Stable ID** | Same rule always gets same ID (SHA-256 based) |
-| **Deduplication** | Similar insights merged, frequency tracked |
-| **Confidence** | high/medium/low based on frequency + recency |
-| **Sources** | Which entries contributed to this rule |
-| **Tags** | Auto-extracted technology/concept keywords |
-
-### Deduplication in Action
-
-Raw patterns from different entries:
-```
-- "Run tests before committing"
-- "Always run the test suite before commit"
-- "Execute tests prior to committing code"
-```
-
-After deduplication → **1 rule** with `frequency: 3`:
-```yaml
-- id: wf-96f12966f1
-  rule: Run tests before committing
-  frequency: 3
-  confidence: high
-```
+Boring? Maybe. But boring things that work beat exciting things that don't.
 
 ---
 
-## Promotion Targets
+## The Falsification Protocol
 
-Rules can be promoted to different targets for agent consumption:
+Want to test whether buildlog actually helps? Here's the protocol:
 
-```mermaid
-flowchart LR
-    R["Rules<br/>(buildlog_status)"] --> T1["CLAUDE.md<br/>(append)"]
-    R --> T2["settings.json<br/>(merge)"]
-    R --> T3[".claude/skills/<br/>(Agent Skill)"]
+1. **Baseline**: Run N sessions without buildlog rules active. Log mistakes.
+2. **Treatment**: Run N sessions with buildlog rules active. Log mistakes.
+3. **Compare**: Calculate RMR for both conditions.
+4. **Statistical test**: Two-proportion z-test or chi-squared.
+5. **Report**: Effect size, confidence interval, p-value.
 
-    T1 --> A1["Always loaded<br/>in context"]
-    T2 --> A2["Project settings<br/>for Claude Code"]
-    T3 --> A3["On-demand loading<br/>saves context"]
+If p > 0.05, we fail to reject the null. buildlog didn't help. That's a valid outcome.
 
-    style T3 fill:#96ceb4,color:#fff
-```
+If p < 0.05, we have evidence of an effect. How big? Check the effect size.
 
-| Target | File | When to Use |
-|--------|------|-------------|
-| `claude_md` | `CLAUDE.md` | Rules always in context (default) |
-| `settings_json` | `.claude/settings.json` | Project-level Claude Code settings |
-| `skill` | `.claude/skills/buildlog-learned/SKILL.md` | **On-demand loading** - rules load only when relevant |
-
-### Anthropic Agent Skills (New!)
-
-The `skill` target creates an [Anthropic Agent Skill](https://docs.anthropic.com/en/docs/claude-code/skills) that Claude loads on-demand:
-
-```bash
-# Via MCP tool
-buildlog_promote(skill_ids=["arch-123", "wf-456"], target="skill")
-```
-
-Creates `.claude/skills/buildlog-learned/SKILL.md`:
-
-```markdown
----
-name: buildlog-learned
-description: Project-specific patterns learned from development history.
-  Use when writing code, making architectural decisions, reviewing PRs,
-  or ensuring consistency. Contains 12 rules across Architectural, Workflow.
----
-
-# Learned Patterns
-
-*12 rules extracted from buildlog entries on 2026-01-16*
-
-## Must Follow (High Confidence)
-
-These patterns have been reinforced multiple times.
-
-### Architectural
-- Always validate inputs at the boundary
-- Use dependency injection for testability
-
-### Workflow
-- Run tests after EVERY code change
-
-## Should Consider (Medium Confidence)
-
-These patterns appear frequently but may have exceptions.
-
-### Tool Usage
-- Prefer `patch` context manager for date mocking
-```
-
-**Why Agent Skills?**
-- **On-demand loading** - Rules only load when Claude determines they're relevant
-- **Saves context** - Not always in context like CLAUDE.md
-- **Progressive disclosure** - Claude asks before loading the full skill
-
-### Live Usage Scenario
-
-Here's how your learned rules actually get used:
-
-```
-┌─────────────────────────────────────────────────────────────────┐
-│ You: "Review this authentication endpoint I wrote"              │
-└─────────────────────────────────────────────────────────────────┘
-                              │
-                              ▼
-┌─────────────────────────────────────────────────────────────────┐
-│ Claude sees: "authentication" + "review" + "endpoint"           │
-│                                                                 │
-│ Checks skill description:                                       │
-│   "Use when writing code, making architectural decisions,       │
-│    reviewing PRs, or ensuring consistency..."                   │
-│                                                                 │
-│ Match! Loads .claude/skills/buildlog-learned/SKILL.md           │
-└─────────────────────────────────────────────────────────────────┘
-                              │
-                              ▼
-┌─────────────────────────────────────────────────────────────────┐
-│ Claude now has access to YOUR learned rules:                    │
-│                                                                 │
-│   Must Follow:                                                  │
-│   - Password hashing belongs in User model, not route handler   │
-│   - Always validate inputs at the boundary                      │
-│                                                                 │
-│   Worth Knowing:                                                │
-│   - bcrypt.compare() arg order is (plaintext, hash)             │
-│   - JWT expiry is in seconds, not milliseconds                  │
-└─────────────────────────────────────────────────────────────────┘
-                              │
-                              ▼
-┌─────────────────────────────────────────────────────────────────┐
-│ Claude: "I notice the password hashing is in your route         │
-│ handler. Based on patterns from your buildlog, this should      │
-│ be a pre-save hook in the User model instead.                   │
-│                                                                 │
-│ Also, I see bcrypt.compare(hash, password) - the argument       │
-│ order should be (plaintext, hash). This has tripped you up      │
-│ before."                                                        │
-└─────────────────────────────────────────────────────────────────┘
-```
-
-Your past mistakes now prevent future ones—automatically.
+This is how you know. Not vibes. Data.
 
 ---
 
-## Embedding Backends
+## Theoretical Foundations
 
-Deduplication uses text similarity. Choose your backend:
+For the technically curious:
 
-| Backend | Install | Use Case |
-|---------|---------|----------|
-| `token` (default) | Built-in | Fast, free, good for obvious duplicates |
-| `sentence-transformers` | `pip install buildlog[embeddings]` | Local semantic similarity, no API calls |
-| `openai` | `pip install buildlog[openai]` | Best quality, requires API key |
+| Concept | Application in buildlog |
+|---------|------------------------|
+| **Thompson Sampling** | Rule selection under uncertainty |
+| **Beta-Bernoulli model** | Posterior updates from binary reward |
+| **Contextual bandits** | Context-dependent rule selection |
+| **Regret bounds** | O(√(KT log K)) theoretical guarantee |
+| **Semantic hashing** | Mistake deduplication for RMR |
 
-```bash
-# Token-based (default) - catches "run tests" ≈ "run testing"
-buildlog skills
-
-# Semantic - catches "use Redis for caching" ≈ "cache data in Redis"
-buildlog skills --embeddings sentence-transformers
-
-# OpenAI - best quality semantic matching
-export OPENAI_API_KEY=...
-buildlog skills --embeddings openai
-```
-
-### Comparison
-
-| Input | Token | OpenAI |
-|-------|:-----:|:------:|
-| "Run tests before commit" ≈ "Run testing before committing" | Merged | Merged |
-| "Use Redis for caching" ≈ "Cache data in Redis" | Separate | Merged |
+We're not inventing new math. We're applying proven frameworks to a new domain.
 
 ---
 
-## Practical Usage
+## Honest Limitations
 
-### 1. Inject Rules into CLAUDE.md
+Things we don't have figured out yet:
 
-```bash
-buildlog skills --format markdown >> CLAUDE.md
-```
+- **Credit assignment**: When multiple rules are active, which one helped?
+- **Non-stationarity**: Developer skill changes over time
+- **Cold start**: New rules have high uncertainty
+- **Context representation**: What features actually matter?
 
-Your AI agent now has access to every lesson you've learned:
-
-```markdown
-## Learned Rules
-
-Based on 23 buildlog entries, 31 actionable rules have emerged:
-
-### Architectural (8 rules)
-- Always validate inputs at the boundary (seen 4x)
-- Use frozen dataclasses for data containers (seen 2x)
-
-### Workflow (12 rules)
-- Run tests after EVERY code change (seen 5x)
-...
-```
-
-### 2. Create an Agent Skill
-
-For on-demand loading instead of always-in-context:
-
-```bash
-# Via CLI (coming soon)
-buildlog promote --target skill
-
-# Via MCP
-buildlog_promote(skill_ids=["arch-123"], target="skill")
-```
-
-### 3. Track Rule Evolution
-
-Rules have stable IDs. Track which are reinforced over time:
-
-```bash
-# This week's new rules
-buildlog skills --since 2026-01-10 -o this-week.yml
-
-# Compare to baseline
-diff baseline.yml this-week.yml
-```
-
-### 4. Find Your Blind Spots
-
-```bash
-buildlog stats --detailed
-```
-
-```
-Buildlog Statistics
-
-Entries: 23 total
-Coverage: 87% with improvements
-
-Category Breakdown:
-  architectural:    12 insights (26%)
-  workflow:         15 insights (33%)
-  tool_usage:        8 insights (17%)
-  domain_knowledge: 11 insights (24%)
-
-Warnings:
-  - 3 entries have empty Improvements sections
-```
-
----
-
-## Commands
-
-| Command | Description |
-|---------|-------------|
-| `buildlog init` | Initialize in current directory |
-| `buildlog new <slug>` | Create entry for today |
-| `buildlog new <slug> --date 2026-01-15` | Create entry for specific date |
-| `buildlog list` | List all entries |
-| `buildlog distill` | Extract patterns from all entries |
-| `buildlog stats` | Show statistics and analytics |
-| `buildlog skills` | Generate deduplicated rules |
-| `buildlog update` | Update templates to latest |
-
-### Skills Options
-
-```bash
---output, -o PATH       # Write to file instead of stdout
---format [yaml|json|markdown]  # Output format (default: yaml)
---min-frequency N       # Only rules seen N+ times
---since YYYY-MM-DD      # Only entries from this date
---embeddings [token|sentence-transformers|openai]  # Similarity backend
-```
-
----
-
-## Architecture
-
-```mermaid
-flowchart TB
-    subgraph CLI["CLI Layer"]
-        cli["cli.py"]
-    end
-
-    subgraph Core["Core Logic"]
-        distill["distill.py<br/>Pattern extraction"]
-        skills["skills.py<br/>Deduplication + scoring"]
-        stats["stats.py<br/>Analytics"]
-        embeddings["embeddings.py<br/>Similarity backends"]
-        ops["core/operations.py<br/>status, promote, reject"]
-    end
-
-    subgraph Render["Render Adapters"]
-        claude_md["claude_md.py"]
-        settings_json["settings_json.py"]
-        skill_render["skill.py"]
-    end
-
-    subgraph MCP["MCP Server"]
-        server["server.py"]
-        tools["tools.py"]
-    end
-
-    cli --> distill
-    cli --> skills
-    cli --> stats
-
-    skills --> embeddings
-    skills --> distill
-
-    ops --> skills
-    ops --> Render
-
-    tools --> ops
-    server --> tools
-```
-
-### Data Flow
-
-```mermaid
-flowchart LR
-    MD["buildlog/*.md"] --> Parse["Parse markdown"]
-    Parse --> Extract["Extract Improvements"]
-    Extract --> Distill["distill_all()"]
-    Distill --> Patterns["Patterns by category"]
-    Patterns --> Dedup["Deduplicate"]
-    Dedup --> Score["Calculate confidence"]
-    Score --> Rules["Rules with IDs"]
-    Rules --> Format["Format output"]
-    Format --> Out["YAML / JSON / Markdown / Agent Skill"]
-```
-
----
-
-## Installation Options
-
-```bash
-# Basic install
-pip install buildlog
-
-# With local semantic embeddings (offline)
-pip install buildlog[embeddings]
-
-# With OpenAI embeddings
-pip install buildlog[openai]
-
-# Everything
-pip install buildlog[all]
-
-# Development
-pip install buildlog[dev]
-
-# With MCP server for Claude Code integration
-pip install buildlog[mcp]
-```
-
----
-
-## MCP Server (Claude Code Integration)
-
-The MCP server lets Claude Code interact with your buildlog rules directly. Your agent can review learned patterns, promote them to rules, or reject false positives—all through natural conversation.
-
-### Setup for Claude Code CLI
-
-1. Install with MCP support:
-   ```bash
-   pip install buildlog[mcp]
-   # or with uv
-   uv pip install buildlog[mcp]
-   ```
-
-2. Add to your Claude Code settings (`~/.claude/settings.json`):
-   ```json
-   {
-     "mcpServers": {
-       "buildlog": {
-         "command": "buildlog-mcp",
-         "args": []
-       }
-     }
-   }
-   ```
-
-3. Start a new Claude Code session. The buildlog tools will be available.
-
-### Available Tools
-
-| Tool | Description |
-|------|-------------|
-| `buildlog_status` | Get rules grouped by category with confidence scores |
-| `buildlog_promote` | Write rules to CLAUDE.md, settings.json, or **Agent Skills** |
-| `buildlog_reject` | Mark rules to exclude from future suggestions |
-| `buildlog_diff` | Show rules pending review (not yet promoted/rejected) |
-| `buildlog_learn_from_review` | Capture learnings from code review feedback |
-
-### Promotion Targets via MCP
-
-```python
-# Append to CLAUDE.md (default)
-buildlog_promote(skill_ids=["arch-123"], target="claude_md")
-
-# Merge into settings.json
-buildlog_promote(skill_ids=["arch-123"], target="settings_json")
-
-# Create Anthropic Agent Skill (NEW!)
-buildlog_promote(skill_ids=["arch-123"], target="skill")
-```
-
-### Example Conversation
-
-```
-You: What patterns have I learned?
-
-Claude: [calls buildlog_status]
-        Based on 23 buildlog entries, you have 31 rules:
-
-        High confidence (ready to promote):
-        - arch-b0fcb62a1e: "Always validate inputs at the boundary"
-        - wf-96f12966f1: "Run tests before committing"
-
-        Would you like me to add these to your CLAUDE.md or create an Agent Skill?
-
-You: Create an Agent Skill so they load on-demand.
-
-Claude: [calls buildlog_promote with target="skill"]
-        Created skill at .claude/skills/buildlog-learned/SKILL.md
-
-        This skill will load on-demand when relevant to your work,
-        saving context for when you need it most.
-```
-
----
-
-## Review Learning System
-
-Beyond manual buildlog entries, buildlog can **learn from code reviews** in real-time. Every review becomes a teaching moment—rules get extracted, persisted, and gain confidence through reinforcement.
-
-### How It Works
-
-```mermaid
-flowchart LR
-    A["Code Review"] --> B["Extract Rules"]
-    B --> C["learn_from_review()"]
-    C --> D["Persist to<br/>.buildlog/review_learnings.json"]
-    D --> E["Rules gain confidence<br/>through reinforcement"]
-    E --> F["Inject into<br/>future sessions"]
-```
-
-### The MCP Tool
-
-```python
-buildlog_learn_from_review(
-    issues=[
-        {
-            "severity": "critical",
-            "category": "architectural",
-            "description": "No bounds validation on score input",
-            "rule_learned": "Validate invariants at function boundaries"
-        }
-    ],
-    source="PR#42"
-)
-```
-
-When the same rule is learned from multiple reviews, its confidence increases automatically.
-
-### Reviewer Skills (The Brutal Feedback Loop)
-
-buildlog ships with **ruthless reviewer personas** that output structured JSON compatible with `buildlog_learn_from_review()`. Every review teaches the system.
-
-| Skill | Trigger | Focus |
-|-------|---------|-------|
-| **Ruthless Reviewer** | `review`, `code review` | Code quality, FP principles, invariants |
-| **Test Terrorist** | `test review`, `coverage audit` | ALL test types: unit, integration, E2E, contract, property-based |
-| **Security Karen** | `security review`, `owasp` | OWASP Top 10, input validation, auth |
-| **Review Gauntlet** | `gauntlet`, `destroy my code` | All three reviewers in sequence |
-
-#### The Review Gauntlet
-
-Run all three reviewers for maximum brutality:
-
-```
-┌─────────────────────────────────────────────────────────────────┐
-│                     THE REVIEW GAUNTLET                         │
-├─────────────────────────────────────────────────────────────────┤
-│                                                                  │
-│   Your Code                                                     │
-│       │                                                         │
-│       ▼                                                         │
-│   ┌──────────────────┐                                          │
-│   │  RUTHLESS        │  "Is this pure? Would it compile        │
-│   │  REVIEWER        │   in Haskell?"                           │
-│   └────────┬─────────┘                                          │
-│            ▼                                                    │
-│   ┌──────────────────┐                                          │
-│   │  TEST            │  "Where are your contract tests?        │
-│   │  TERRORIST       │   Show me the Gherkin."                  │
-│   └────────┬─────────┘                                          │
-│            ▼                                                    │
-│   ┌──────────────────┐                                          │
-│   │  SECURITY        │  "I need to speak to your security      │
-│   │  KAREN           │   manager about this SQL query."         │
-│   └────────┬─────────┘                                          │
-│            ▼                                                    │
-│   Combined Issues → buildlog_learn_from_review()               │
-│            ▼                                                    │
-│   Future sessions get smarter                                   │
-│                                                                  │
-└──────────────────────────────────────────────────────────────────┘
-```
-
-Each reviewer outputs structured JSON:
-
-```json
-{
-  "verdict": "BLOCKED",
-  "issues": [
-    {
-      "severity": "critical",
-      "category": "architectural",
-      "location": "src/api/handler.py:45",
-      "description": "Score bounds not validated",
-      "rule_learned": "Validate invariants at function boundaries",
-      "functional_principle": "Parse, don't validate"
-    }
-  ]
-}
-```
-
-After review, call `buildlog_learn_from_review(issues=...)` to persist the learnings.
-
-### Test Terrorist Coverage
-
-The Test Terrorist knows ALL test types:
-
-| Layer | Test Types |
-|-------|-----------|
-| **Fundamentals** | Unit, Integration, E2E, Smoke |
-| **User Flows** | BDD scenarios, persistence tests |
-| **Advanced** | Contract (Pact), Property-based (Hypothesis), Metamorphic, Statistical, Mutation |
-| **Specialized** | Chaos, Load/Performance, Accessibility |
-
-**Contract tests are NON-NEGOTIABLE** for service boundaries. The Test Terrorist will find your missing ones.
-
-### Security Karen's OWASP Obsession
-
-Security Karen audits against OWASP Top 10 (2021):
-
-- **A01**: Broken Access Control
-- **A02**: Cryptographic Failures
-- **A03**: Injection
-- **A04**: Insecure Design
-- **A05**: Security Misconfiguration
-- **A06**: Vulnerable Components
-- **A07**: Auth Failures
-- **A08**: Integrity Failures
-- **A09**: Logging Failures
-- **A10**: SSRF
-
-Plus: secrets management, input validation, API security, error handling.
+These are hard problems. We have directional ideas, not solutions. If you're a researcher working on bandit algorithms or causal inference, we'd love to talk.
 
 ---
 
 ## Philosophy
 
-### 1. Write Fast, Not Pretty
-Refrigerator to-do list energy. Get it down before you forget.
-
-### 2. Never Delete Mistakes
-Wrong turns are the most valuable content. They're what makes tutorials actually useful.
-
-### 3. Include the Journey
-"We tried X, it failed because Y, so we did Z" > "We did Z"
-
-### 4. Capture Improvements
-Concrete learnings, not vague observations. "Always validate at boundary" > "validation is important"
-
-### 5. Quality Bar
-Each entry should be publishable as a **$500+ tutorial**. Real error messages. Honest about what didn't work. Code that runs.
+1. **Falsifiability over impressiveness** - If you can't prove it wrong, it's not a claim
+2. **Measurement over intuition** - "Feels better" is not evidence
+3. **Mechanisms over magic** - Explain how it works or admit you don't know
+4. **Boring over exciting** - Proven frameworks beat novel demos
+5. **Honesty over marketing** - State limitations. Invite scrutiny.
 
 ---
 
 ## Contributing
 
-1. Fork the repository
-2. Create a feature branch (`git checkout -b feature/amazing`)
-3. Commit your changes (`git commit -m 'Add amazing feature'`)
-4. Push to the branch (`git push origin feature/amazing`)
-5. Open a Pull Request
+We're especially interested in:
+- Better context representations for the bandit
+- Credit assignment approaches
+- Statistical methodology improvements
+- Real-world experiment results (positive or negative)
+
+```bash
+git clone https://github.com/Peleke/buildlog-template
+cd buildlog-template
+pip install -e ".[dev]"
+pytest
+```
 
 ---
 
 ## License
 
-MIT License — see [LICENSE](./LICENSE) for details.
+MIT License — see [LICENSE](./LICENSE)
 
 ---
 
 <div align="center">
 
-**Your AI pair programmer should learn from your mistakes.**
+**"Agent learning" without measurement is just prompt engineering with extra steps.**
 
-**buildlog makes that possible.**
+**buildlog is measurement.**
 
 [Back to top](#buildlog)
 


### PR DESCRIPTION
## Summary
- Complete README rewrite focused on pitch for high-tier reviewers
- Leads with falsifiable claims, not feature lists
- Introduces RMR (Repeated Mistake Rate) as the core metric
- Explains contextual bandit mechanism without academic density
- Documents all new features (experiment infra, reward signals)
- Includes honest limitations section
- "If you know you know" positioning

## The Vibe
No names dropped. But if you're paying attention to the "agent memory" space, you know exactly who we're positioning against. And why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)