### PR TITLE
feat: npm/bunx wrapper for TypeScript projects

### DIFF
--- a/packages/buildlog-npm/README.md
+++ b/packages/buildlog-npm/README.md
@@ -1,0 +1,67 @@
+# buildlog
+
+Engineering notebook for AI-assisted development. Capture your work as publishable content. Include the fuckups.
+
+This is the npm wrapper for [buildlog](https://github.com/Peleke/buildlog-template). It lets you use buildlog via `npx`/`bunx` in TypeScript and JavaScript projects.
+
+## Quick start
+
+```bash
+npx buildlog init
+npx buildlog new my-feature
+npx buildlog commit -m "feat: add auth"
+npx buildlog skills
+npx buildlog gauntlet loop src/
+```
+
+## Install
+
+```bash
+# One-off (no install needed)
+npx buildlog init
+
+# Pin as dev dependency
+npm install -D buildlog
+# or
+bun add -D buildlog
+```
+
+## Requirements
+
+Python 3.10+ must be available. The npm package is a thin wrapper that invokes the Python CLI.
+
+If `buildlog` isn't already installed, the wrapper will try `uvx buildlog` (auto-downloads from PyPI) or `python -m buildlog` as fallbacks.
+
+To install the Python CLI directly:
+
+```bash
+pip install buildlog
+# or
+uv tool install buildlog
+```
+
+## How it works
+
+The npm package ships a single bin shim that:
+
+1. Looks for `buildlog` on PATH
+2. Falls back to `uvx buildlog` (zero-install via uv)
+3. Falls back to `python3 -m buildlog`
+4. Passes through all arguments and stdio transparently
+
+Every command works identically to the Python CLI. See the [full documentation](https://github.com/Peleke/buildlog-template) for details.
+
+## package.json scripts
+
+```json
+{
+  "scripts": {
+    "gauntlet": "buildlog gauntlet loop src/",
+    "buildlog:commit": "buildlog commit"
+  }
+}
+```
+
+## License
+
+MIT

--- a/packages/buildlog-npm/bin/buildlog.mjs
+++ b/packages/buildlog-npm/bin/buildlog.mjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+
+/**
+ * buildlog npm wrapper
+ *
+ * Thin shim that finds and invokes the Python buildlog CLI.
+ * Resolution order:
+ *   1. `buildlog` on PATH (pip install / pipx / system)
+ *   2. `uvx buildlog` (auto-downloads, no install needed)
+ *   3. `python3 -m buildlog` / `python -m buildlog`
+ *
+ * All arguments and stdio are passed through transparently.
+ */
+
+import { spawn, execFileSync } from "node:child_process";
+
+const args = process.argv.slice(2);
+
+/**
+ * Check if a command exists on PATH.
+ */
+function commandExists(cmd) {
+  try {
+    execFileSync(process.platform === "win32" ? "where" : "which", [cmd], {
+      stdio: "ignore",
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Spawn a child process with full stdio passthrough.
+ * Returns a promise that resolves with the exit code.
+ */
+function run(cmd, cmdArgs) {
+  return new Promise((resolve) => {
+    const child = spawn(cmd, cmdArgs, {
+      stdio: "inherit",
+      env: process.env,
+    });
+
+    child.on("error", () => resolve(null));
+    child.on("close", (code) => resolve(code));
+  });
+}
+
+async function main() {
+  // Strategy 1: buildlog on PATH
+  if (commandExists("buildlog")) {
+    const code = await run("buildlog", args);
+    if (code !== null) process.exit(code);
+  }
+
+  // Strategy 2: uvx buildlog (auto-downloads from PyPI)
+  if (commandExists("uvx")) {
+    const code = await run("uvx", ["buildlog", ...args]);
+    if (code !== null) process.exit(code);
+  }
+
+  // Strategy 3: python -m buildlog
+  for (const python of ["python3", "python"]) {
+    if (commandExists(python)) {
+      const code = await run(python, ["-m", "buildlog", ...args]);
+      if (code !== null) process.exit(code);
+    }
+  }
+
+  // Nothing worked
+  console.error(`buildlog: Python CLI not found.
+
+Install buildlog (pick one):
+  pip install buildlog
+  uv tool install buildlog
+  pipx install buildlog
+
+Or install Python: https://www.python.org/downloads/
+
+The npm package is a thin wrapper around the Python CLI.
+Python is required to run buildlog.`);
+  process.exit(127);
+}
+
+main();

--- a/packages/buildlog-npm/package.json
+++ b/packages/buildlog-npm/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "buildlog",
+  "version": "0.7.0",
+  "description": "Engineering notebook for AI-assisted development. Capture your work as publishable content.",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Peleke/buildlog-template.git",
+    "directory": "packages/buildlog-npm"
+  },
+  "homepage": "https://github.com/Peleke/buildlog-template",
+  "keywords": [
+    "buildlog",
+    "ai",
+    "development",
+    "engineering-notebook",
+    "claude",
+    "cursor",
+    "copilot",
+    "agent-rules"
+  ],
+  "bin": {
+    "buildlog": "bin/buildlog.mjs"
+  },
+  "type": "module",
+  "engines": {
+    "node": ">=18"
+  },
+  "files": [
+    "bin/",
+    "README.md"
+  ]
+}


### PR DESCRIPTION
## Summary

- Thin npm shim (`packages/buildlog-npm/`) so TS/JS devs can `npx buildlog` or `bunx buildlog`
- Resolution: `buildlog` on PATH → `uvx buildlog` → `python -m buildlog`
- All args + stdio pass through transparently
- Helpful error when Python not found

## Usage

```bash
npx buildlog init
npx buildlog commit -m "feat: stuff"
npx buildlog gauntlet loop src/
```

Or pin as dev dep:
```bash
npm install -D buildlog
```

Closes #59

## Test plan

- [x] `node packages/buildlog-npm/bin/buildlog.mjs --version` — works, finds Python CLI
- [x] Args and exit codes pass through
- [ ] E2E: `npx buildlog init` in a fresh TS repo (will do before merge)
- [ ] Publish to npm (post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)