### PR TITLE
chore: release v0.9.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -111,10 +111,36 @@ jobs:
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
 
+  publish-npm:
+    name: Publish to npm
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    needs: publish-pypi
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/buildlog-npm
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Sync version from tag
+        run: |
+          TAG_VERSION="${GITHUB_REF#refs/tags/v}"
+          npm version "$TAG_VERSION" --no-git-tag-version
+
+      - name: Publish to npm
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
   github-release:
     name: Create GitHub Release
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-    needs: publish-pypi
+    needs: [publish-pypi, publish-npm]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-02-01
+
+### Added
+- **Bragi persona**: LLM prose pattern detection with 9 rules (em-dash abuse, tricolons, performative honesty, rhythmic closers, etc.)
+- **Bragi Claude Code skill**: interactive markdown review with 3 ranked rewrite suggestions per finding
+- **Auto-gauntlet**: hybrid commit gate with Claude Code hooks
+- **Thompson Sampling bandit**: rule selection via contextual bandits with Beta posteriors
+- **Metered LLM backend**: token usage and cost tracking, pure Python statistics
+- **npm wrapper**: `npx @peleke.s/buildlog` for JS/TS projects
+- npm publish job in release workflow
+
+### Changed
+- README de-LLM-ified: removed all em dashes and LLM prose patterns (dogfooded via bragi)
+- Package scope changed to `@peleke.s/buildlog` on npm
+
 ## [0.8.0] - 2026-01-31
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ buildlog experiment report
 - **Review gauntlet:** automated quality gate with curated reviewer personas. Runs on commits (via Claude Code hooks or CI) and files GitHub issues for findings, categorized by severity.
 - **LLM-backed extraction:** when regex isn't enough, the seed engine can use OpenAI, Anthropic, or Ollama to extract patterns from code and logs. Metered backend tracks token usage and cost.
 - **MCP server:** buildlog exposes itself as an MCP server so agents can query seeds, skills, and build history programmatically during sessions.
-- **npm wrapper:** `npx @peleke/buildlog` for JS/TS projects. Thin shim that finds and invokes the Python CLI.
+- **npm wrapper:** `npx @peleke.s/buildlog` for JS/TS projects. Thin shim that finds and invokes the Python CLI.
 
 ## Current Limits
 

--- a/packages/buildlog-npm/README.md
+++ b/packages/buildlog-npm/README.md
@@ -7,18 +7,18 @@ This is the npm wrapper for [buildlog](https://github.com/Peleke/buildlog-templa
 ## Quick start
 
 ```bash
-npx buildlog init
-npx buildlog new my-feature
-npx buildlog commit -m "feat: add auth"
-npx buildlog skills
-npx buildlog gauntlet loop src/
+npx @peleke.s/buildlog init
+npx @peleke.s/buildlog new my-feature
+npx @peleke.s/buildlog commit -m "feat: add auth"
+npx @peleke.s/buildlog skills
+npx @peleke.s/buildlog gauntlet loop src/
 ```
 
 ## Install
 
 ```bash
 # One-off (no install needed)
-npx buildlog init
+npx @peleke.s/buildlog init
 
 # Pin as dev dependency
 npm install -D buildlog

--- a/packages/buildlog-npm/package.json
+++ b/packages/buildlog-npm/package.json
@@ -1,5 +1,8 @@
 {
-  "name": "buildlog",
+  "name": "@peleke.s/buildlog",
+  "publishConfig": {
+    "access": "public"
+  },
   "version": "0.7.0",
   "description": "Engineering notebook for AI-assisted development. Capture your work as publishable content.",
   "license": "MIT",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "buildlog"
-version = "0.8.0"
+version = "0.9.0"
 description = "Engineering notebook for AI-assisted development"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Bump version to 0.9.0
- CHANGELOG entry for all PRs merged this session (#56, #58, #44, #61, #64, #60)
- Scope npm package as `@peleke.s/buildlog` with `publishConfig.access: "public"`
- Add `publish-npm` job to release workflow

## After merge
```bash
git tag v0.9.0 && git push origin v0.9.0
```
This triggers the release workflow: PyPI + npm + GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)