### PR TITLE
fix(ci): allow same npm version in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -130,7 +130,7 @@ jobs:
       - name: Sync version from tag
         run: |
           TAG_VERSION="${GITHUB_REF#refs/tags/v}"
-          npm version "$TAG_VERSION" --no-git-tag-version
+          npm version "$TAG_VERSION" --no-git-tag-version --allow-same-version
 
       - name: Publish to npm
         run: npm publish


### PR DESCRIPTION
## Summary
- npm version fails when package.json already matches the tag version
- Add `--allow-same-version` flag so the sync step is idempotent
- Fixes npm publish failure in v0.9.0 release (PyPI succeeded, npm did not)

🤖 Generated with [Claude Code](https://claude.com/claude-code)