### PR TITLE
fix(ci): switch npm to OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -116,6 +116,8 @@ jobs:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     needs: publish-pypi
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     defaults:
       run:
         working-directory: packages/buildlog-npm
@@ -124,7 +126,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
 
       - name: Sync version from tag
@@ -133,9 +135,7 @@ jobs:
           npm version "$TAG_VERSION" --no-git-tag-version --allow-same-version
 
       - name: Publish to npm
-        run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --provenance --access public
 
   github-release:
     name: Create GitHub Release


### PR DESCRIPTION
## Summary
- Replace `NPM_TOKEN` secret with OIDC trusted publishing (same approach as PyPI)
- Bump Node to 24 (required for npm >= 11.5.1 trusted publishing support)
- Add `--provenance` flag for supply chain attestation
- Classic npm tokens were deprecated Dec 2025; this is the correct path forward

## Setup required on npmjs.com
Configure trusted publisher for `@peleke.s/buildlog`:
- Owner: `Peleke`
- Repository: `buildlog-template`  
- Workflow: `publish.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)