### PR TITLE
chore: merge global always-on mode into main

### DIFF
--- a/docs/plans/global-always-on.md
+++ b/docs/plans/global-always-on.md
@@ -1,0 +1,83 @@
+# Global Always-On Mode
+
+> **Issue:** #79
+> **Status:** Planning
+> **Target:** v0.11.0 or v0.12.0
+
+## Current Workflow (v0.10.0)
+
+```bash
+# Install globally
+pipx install buildlog          # or: uv tool install buildlog
+
+# Per-project setup (required)
+cd my-project
+buildlog init --defaults       # creates buildlog/, .claude/settings.json, updates CLAUDE.md
+```
+
+## Proposed Workflow
+
+```bash
+# One-time global setup
+pipx install buildlog
+buildlog init-mcp --global     # registers in ~/.claude/settings.json
+
+# Use anywhere (no per-project init required)
+cd any-project
+# Claude Code already has access to all 29 buildlog tools
+```
+
+## What Changes
+
+### 1. Global MCP Registration
+
+```python
+# cli.py
+@main.command("init-mcp")
+@click.option("--global", "global_", is_flag=True, help="Register globally in ~/.claude/settings.json")
+def init_mcp(global_: bool):
+    if global_:
+        settings_path = Path.home() / ".claude" / "settings.json"
+    else:
+        settings_path = Path(".claude") / "settings.json"
+    # ... rest of logic unchanged
+```
+
+### 2. Graceful Fallbacks
+
+Commands that currently require `buildlog/` should handle missing directories:
+
+```python
+# Before
+if not buildlog_dir.exists():
+    click.echo("No buildlog/ directory found. Run 'buildlog init' first.", err=True)
+    raise SystemExit(1)
+
+# After
+if not buildlog_dir.exists():
+    # Return empty/default state instead of erroring
+    return EmptyResult(initialized=False, message="Run 'buildlog init' to enable full features")
+```
+
+### 3. Global State Directory
+
+```
+~/.buildlog/
+├── seeds/              # Custom personas (merged with package bundled)
+├── rewards.jsonl       # Optional: cross-project reward tracking
+└── config.yaml         # Global preferences
+```
+
+## Migration Path
+
+1. v0.10.0: Current per-project model (ship as-is)
+2. v0.11.0: Add `--global` flag, graceful fallbacks
+3. v0.12.0: Global state directory, cross-project features
+
+## Implementation Checklist
+
+- [ ] Add `--global` flag to `init-mcp`
+- [ ] Update `_init_mcp()` to accept path parameter
+- [ ] Add graceful fallbacks to: `overview`, `skills`, `status`, `stats`
+- [ ] Document "always-on" workflow in installation guide
+- [ ] Test with fresh system (no local buildlog/)

--- a/src/buildlog/cli.py
+++ b/src/buildlog/cli.py
@@ -160,11 +160,19 @@ def init(no_claude_md: bool, no_mcp: bool, defaults: bool):
     click.echo("Start now: buildlog new my-first-task --quick")
 
 
-def _init_mcp() -> None:
-    """Register buildlog as an MCP server in .claude/settings.json."""
+def _init_mcp(settings_path: Path | None = None, global_mode: bool = False) -> None:
+    """Register buildlog as an MCP server in settings.json.
+
+    Args:
+        settings_path: Path to settings.json. Defaults to .claude/settings.json
+        global_mode: If True, display global-specific messaging
+    """
     import json as json_module
 
-    settings_path = Path(".claude") / "settings.json"
+    if settings_path is None:
+        settings_path = Path(".claude") / "settings.json"
+
+    location = "~/.claude/settings.json" if global_mode else ".claude/settings.json"
 
     try:
         if settings_path.exists():
@@ -172,7 +180,7 @@ def _init_mcp() -> None:
                 data = json_module.loads(settings_path.read_text())
             except json_module.JSONDecodeError:
                 click.echo(
-                    "Warning: .claude/settings.json is malformed, skipping MCP registration",
+                    f"Warning: {location} is malformed, skipping MCP registration",
                     err=True,
                 )
                 return
@@ -183,30 +191,46 @@ def _init_mcp() -> None:
             data["mcpServers"] = {}
 
         if "buildlog" in data["mcpServers"]:
-            click.echo("buildlog MCP server already registered")
+            click.echo(f"buildlog MCP server already registered in {location}")
             return
 
         data["mcpServers"]["buildlog"] = {"command": "buildlog-mcp", "args": []}
 
         settings_path.parent.mkdir(parents=True, exist_ok=True)
         settings_path.write_text(json_module.dumps(data, indent=2) + "\n")
-        click.echo("Registered buildlog MCP server in .claude/settings.json")
+        click.echo(f"Registered buildlog MCP server in {location}")
+        if global_mode:
+            click.echo("Claude Code now has access to buildlog tools in all projects.")
     except Exception as e:
         click.echo(f"Warning: could not register MCP server: {e}", err=True)
 
 
 @main.command("init-mcp")
-def init_mcp():
+@click.option(
+    "--global",
+    "global_",
+    is_flag=True,
+    help="Register globally in ~/.claude/settings.json (works in any project)",
+)
+def init_mcp(global_: bool):
     """Register buildlog as an MCP server for Claude Code.
 
     Creates or updates .claude/settings.json with the buildlog MCP
     server configuration. Idempotent — safe to run multiple times.
 
+    Use --global to register in ~/.claude/settings.json so buildlog
+    tools are available in every project without per-project init.
+
     Examples:
 
-        buildlog init-mcp
+        buildlog init-mcp              # local (current project)
+        buildlog init-mcp --global     # global (all projects)
     """
-    _init_mcp()
+    if global_:
+        settings_path = Path.home() / ".claude" / "settings.json"
+        _init_mcp(settings_path=settings_path, global_mode=True)
+    else:
+        _init_mcp()
 
 
 @main.command("mcp-test")
@@ -254,6 +278,7 @@ def overview(output_json: bool):
     """Show the full state of your buildlog at a glance.
 
     Entries, skills, promoted rules, experiments — everything in one view.
+    Works even without buildlog init (shows uninitialized state).
 
     Examples:
 
@@ -264,9 +289,38 @@ def overview(output_json: bool):
 
     buildlog_dir = Path("buildlog")
 
+    # Handle uninitialized state gracefully
     if not buildlog_dir.exists():
-        click.echo("No buildlog/ directory found. Run 'buildlog init' first.", err=True)
-        raise SystemExit(1)
+        result = {
+            "initialized": False,
+            "entries": 0,
+            "skills": {
+                "total": 0,
+                "by_confidence": {},
+                "promoted": 0,
+                "rejected": 0,
+                "pending": 0,
+            },
+            "active_session": None,
+            "render_targets": [],
+            "message": "buildlog not initialized. Run 'buildlog init' to enable full features.",
+        }
+        if output_json:
+            click.echo(json_module.dumps(result, indent=2))
+        else:
+            click.echo("buildlog overview")
+            click.echo("=" * 40)
+            click.echo("  Status:      Not initialized")
+            click.echo()
+            click.echo("Get started:")
+            click.echo("  buildlog init --defaults    # Initialize buildlog")
+            click.echo()
+            click.echo("Or use globally without init:")
+            click.echo("  buildlog init-mcp --global  # Register MCP server globally")
+            click.echo(
+                "  buildlog gauntlet list      # Review personas work without init"
+            )
+        return
 
     # Count entries
     entries = sorted(buildlog_dir.glob("20??-??-??-*.md"))
@@ -314,6 +368,7 @@ def overview(output_json: bool):
     from buildlog.render import RENDERERS
 
     result = {
+        "initialized": True,
         "entries": len(entries),
         "skills": {
             "total": total_skills,
@@ -692,7 +747,7 @@ def distill(
     """Extract patterns from all buildlog entries.
 
     Parses the Improvements section of each buildlog entry and aggregates
-    insights into structured output (JSON or YAML).
+    insights into structured output (JSON or YAML). Returns empty result if not initialized.
 
     Examples:
 
@@ -702,11 +757,25 @@ def distill(
         buildlog distill --since 2026-01-01    # Filter by date
         buildlog distill --category workflow   # Filter by category
     """
+    import json as json_module
+
     buildlog_dir = Path("buildlog")
 
+    # Handle uninitialized state gracefully
     if not buildlog_dir.exists():
-        click.echo("No buildlog/ directory found. Run 'buildlog init' first.", err=True)
-        raise SystemExit(1)
+        empty_result = {
+            "initialized": False,
+            "patterns": [],
+            "statistics": {"total_patterns": 0, "total_entries": 0},
+            "message": "buildlog not initialized",
+        }
+        if fmt == "json":
+            click.echo(json_module.dumps(empty_result, indent=2))
+        else:
+            click.echo(
+                "# buildlog not initialized - run 'buildlog init' first\npatterns: []"
+            )
+        return
 
     # Convert datetime to date if provided
     since_date = since.date() if since else None
@@ -757,6 +826,7 @@ def stats(output_json: bool, detailed: bool, since_date: str | None):
     """Show buildlog statistics and analytics.
 
     Provides insights on buildlog usage, coverage, and quality.
+    Returns empty stats if not initialized.
 
     Examples:
 
@@ -765,11 +835,27 @@ def stats(output_json: bool, detailed: bool, since_date: str | None):
         buildlog stats --detailed   # Include top sources
         buildlog stats --since 2026-01-01
     """
+    import json as json_module
+
     buildlog_dir = Path("buildlog")
 
+    # Handle uninitialized state gracefully
     if not buildlog_dir.exists():
-        click.echo("No buildlog/ directory found. Run 'buildlog init' first.", err=True)
-        raise SystemExit(1)
+        empty_stats = {
+            "initialized": False,
+            "total_entries": 0,
+            "total_patterns": 0,
+            "categories": {},
+            "date_range": None,
+            "message": "buildlog not initialized",
+        }
+        if output_json:
+            click.echo(json_module.dumps(empty_stats, indent=2))
+        else:
+            click.echo("buildlog stats")
+            click.echo("=" * 40)
+            click.echo("  Not initialized. Run 'buildlog init' first.")
+        return
 
     # Parse since date if provided
     parsed_since = None
@@ -832,7 +918,7 @@ def skills(
     """Generate agent-consumable skills from buildlog patterns.
 
     Transforms distilled patterns into actionable rules with deduplication,
-    confidence scoring, and stable IDs.
+    confidence scoring, and stable IDs. Returns empty set if not initialized.
 
     Examples:
 
@@ -849,9 +935,31 @@ def skills(
     """
     buildlog_dir = Path("buildlog")
 
+    # Handle uninitialized state gracefully - return empty skill set
     if not buildlog_dir.exists():
-        click.echo("No buildlog/ directory found. Run 'buildlog init' first.", err=True)
-        raise SystemExit(1)
+        if fmt == "json":
+            import json as json_module
+
+            click.echo(
+                json_module.dumps(
+                    {
+                        "initialized": False,
+                        "skills": {},
+                        "total_skills": 0,
+                        "message": "buildlog not initialized",
+                    },
+                    indent=2,
+                )
+            )
+        elif fmt == "yaml":
+            click.echo(
+                "# buildlog not initialized - run 'buildlog init' first\nskills: {}\ntotal_skills: 0"
+            )
+        else:
+            click.echo(
+                "No buildlog/ directory found. Run 'buildlog init' to extract skills."
+            )
+        return
 
     # Convert datetime to date if provided
     since_date = since.date() if since else None
@@ -1041,7 +1149,7 @@ def status_cmd(min_confidence: str, output_json: bool):
     """Show extracted skills by category and confidence.
 
     Displays all skills extracted from buildlog entries, grouped by category,
-    with confidence levels and promotion status.
+    with confidence levels and promotion status. Returns empty state if not initialized.
 
     Examples:
 
@@ -1054,9 +1162,23 @@ def status_cmd(min_confidence: str, output_json: bool):
 
     buildlog_dir = Path("buildlog")
 
+    # Handle uninitialized state gracefully
     if not buildlog_dir.exists():
-        click.echo("No buildlog/ directory found. Run 'buildlog init' first.", err=True)
-        raise SystemExit(1)
+        empty_result = {
+            "initialized": False,
+            "total_skills": 0,
+            "total_entries": 0,
+            "skills": {},
+            "by_confidence": {"high": 0, "medium": 0, "low": 0},
+            "promotable_ids": [],
+            "error": None,
+        }
+        if output_json:
+            click.echo(json_module.dumps(empty_result, indent=2))
+        else:
+            click.echo("Skills: 0 total from 0 entries")
+            click.echo("  buildlog not initialized. Run 'buildlog init' first.")
+        return
 
     result = status(buildlog_dir, min_confidence=min_confidence)  # type: ignore[arg-type]
 
@@ -1198,6 +1320,7 @@ def diff_cmd(output_json: bool):
     """Show skills pending review (not yet promoted or rejected).
 
     Useful for seeing what's new since the last time you reviewed skills.
+    Returns empty diff if not initialized.
 
     Examples:
 
@@ -1209,9 +1332,22 @@ def diff_cmd(output_json: bool):
 
     buildlog_dir = Path("buildlog")
 
+    # Handle uninitialized state gracefully
     if not buildlog_dir.exists():
-        click.echo("No buildlog/ directory found. Run 'buildlog init' first.", err=True)
-        raise SystemExit(1)
+        empty_result = {
+            "initialized": False,
+            "pending": {},
+            "total_pending": 0,
+            "already_promoted": 0,
+            "already_rejected": 0,
+            "error": None,
+        }
+        if output_json:
+            click.echo(json_module.dumps(empty_result, indent=2))
+        else:
+            click.echo("Pending: 0 | Promoted: 0 | Rejected: 0")
+            click.echo("  buildlog not initialized. Run 'buildlog init' first.")
+        return
 
     result = core_diff(buildlog_dir)
 

--- a/tests/test_global_always_on.py
+++ b/tests/test_global_always_on.py
@@ -1,0 +1,556 @@
+"""Exhaustive tests for global always-on mode.
+
+Tests cover:
+1. Global MCP registration (--global flag)
+2. Graceful fallbacks for all commands without buildlog/
+3. Path handling edge cases
+4. JSON vs terminal output consistency
+"""
+
+import json
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from buildlog.cli import main
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def runner():
+    """Click CLI test runner."""
+    return CliRunner()
+
+
+@pytest.fixture
+def isolated_fs(runner):
+    """Run test in isolated filesystem (no buildlog/ directory)."""
+    with runner.isolated_filesystem():
+        yield
+
+
+@pytest.fixture
+def mock_home(tmp_path):
+    """Mock home directory for global config tests."""
+    home = tmp_path / "home"
+    home.mkdir()
+    with patch.object(Path, "home", return_value=home):
+        yield home
+
+
+# =============================================================================
+# 1. Global MCP Registration Tests
+# =============================================================================
+
+
+class TestInitMcpGlobal:
+    """Tests for buildlog init-mcp --global command."""
+
+    def test_global_flag_creates_home_claude_dir(self, runner, mock_home):
+        """--global creates ~/.claude/ directory if missing."""
+        result = runner.invoke(main, ["init-mcp", "--global"])
+        assert result.exit_code == 0
+        assert (mock_home / ".claude").exists()
+        assert (mock_home / ".claude" / "settings.json").exists()
+
+    def test_global_flag_writes_correct_path(self, runner, mock_home):
+        """--global writes to ~/.claude/settings.json, not local."""
+        result = runner.invoke(main, ["init-mcp", "--global"])
+        assert result.exit_code == 0
+
+        # Global file should exist
+        global_settings = mock_home / ".claude" / "settings.json"
+        assert global_settings.exists()
+
+        # Local file should NOT exist
+        local_settings = Path(".claude") / "settings.json"
+        assert not local_settings.exists()
+
+    def test_global_flag_correct_mcp_config(self, runner, mock_home):
+        """--global writes correct buildlog MCP server config."""
+        result = runner.invoke(main, ["init-mcp", "--global"])
+        assert result.exit_code == 0
+
+        settings = json.loads((mock_home / ".claude" / "settings.json").read_text())
+        assert "mcpServers" in settings
+        assert "buildlog" in settings["mcpServers"]
+        assert settings["mcpServers"]["buildlog"]["command"] == "buildlog-mcp"
+        assert settings["mcpServers"]["buildlog"]["args"] == []
+
+    def test_global_flag_preserves_existing_servers(self, runner, mock_home):
+        """--global preserves existing MCP servers in config."""
+        # Pre-populate with another server
+        claude_dir = mock_home / ".claude"
+        claude_dir.mkdir()
+        existing = {
+            "mcpServers": {"other-server": {"command": "other", "args": ["-x"]}}
+        }
+        (claude_dir / "settings.json").write_text(json.dumps(existing))
+
+        result = runner.invoke(main, ["init-mcp", "--global"])
+        assert result.exit_code == 0
+
+        settings = json.loads((claude_dir / "settings.json").read_text())
+        assert "other-server" in settings["mcpServers"]
+        assert "buildlog" in settings["mcpServers"]
+
+    def test_global_flag_idempotent(self, runner, mock_home):
+        """Running --global twice doesn't duplicate entry."""
+        runner.invoke(main, ["init-mcp", "--global"])
+        result = runner.invoke(main, ["init-mcp", "--global"])
+
+        assert result.exit_code == 0
+        assert "already registered" in result.output
+
+        settings = json.loads((mock_home / ".claude" / "settings.json").read_text())
+        assert len(settings["mcpServers"]) == 1
+
+    def test_global_flag_shows_global_path_in_output(self, runner, mock_home):
+        """--global output mentions ~/.claude/settings.json."""
+        result = runner.invoke(main, ["init-mcp", "--global"])
+        assert "~/.claude/settings.json" in result.output
+
+    def test_global_flag_shows_all_projects_message(self, runner, mock_home):
+        """--global output mentions it works in all projects."""
+        result = runner.invoke(main, ["init-mcp", "--global"])
+        assert "all projects" in result.output.lower()
+
+    def test_local_mode_default(self, runner, isolated_fs):
+        """Without --global, writes to local .claude/settings.json."""
+        result = runner.invoke(main, ["init-mcp"])
+        assert result.exit_code == 0
+        assert Path(".claude/settings.json").exists()
+
+    def test_local_mode_shows_local_path(self, runner, isolated_fs):
+        """Local mode output mentions .claude/settings.json."""
+        result = runner.invoke(main, ["init-mcp"])
+        assert ".claude/settings.json" in result.output
+        assert "~/.claude" not in result.output
+
+    def test_global_handles_malformed_existing_json(self, runner, mock_home):
+        """--global handles malformed existing settings.json gracefully."""
+        claude_dir = mock_home / ".claude"
+        claude_dir.mkdir()
+        (claude_dir / "settings.json").write_text("{ invalid json }")
+
+        result = runner.invoke(main, ["init-mcp", "--global"])
+        assert result.exit_code == 0
+        assert "malformed" in result.output.lower()
+
+
+# =============================================================================
+# 2. Graceful Fallback Tests - Overview Command
+# =============================================================================
+
+
+class TestOverviewFallback:
+    """Tests for buildlog overview without buildlog/ directory."""
+
+    def test_overview_no_buildlog_returns_zero_exit(self, runner, isolated_fs):
+        """overview without buildlog/ returns exit code 0, not error."""
+        result = runner.invoke(main, ["overview"])
+        assert result.exit_code == 0
+
+    def test_overview_no_buildlog_shows_not_initialized(self, runner, isolated_fs):
+        """overview without buildlog/ shows 'not initialized' message."""
+        result = runner.invoke(main, ["overview"])
+        assert "not initialized" in result.output.lower()
+
+    def test_overview_no_buildlog_suggests_init(self, runner, isolated_fs):
+        """overview without buildlog/ suggests running init."""
+        result = runner.invoke(main, ["overview"])
+        assert "buildlog init" in result.output
+
+    def test_overview_no_buildlog_suggests_global(self, runner, isolated_fs):
+        """overview without buildlog/ suggests global mode."""
+        result = runner.invoke(main, ["overview"])
+        assert "init-mcp --global" in result.output
+
+    def test_overview_no_buildlog_json_has_initialized_false(self, runner, isolated_fs):
+        """overview --json without buildlog/ has initialized: false."""
+        result = runner.invoke(main, ["overview", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["initialized"] is False
+
+    def test_overview_no_buildlog_json_has_zero_entries(self, runner, isolated_fs):
+        """overview --json without buildlog/ has entries: 0."""
+        result = runner.invoke(main, ["overview", "--json"])
+        data = json.loads(result.output)
+        assert data["entries"] == 0
+
+    def test_overview_no_buildlog_json_has_zero_skills(self, runner, isolated_fs):
+        """overview --json without buildlog/ has skills.total: 0."""
+        result = runner.invoke(main, ["overview", "--json"])
+        data = json.loads(result.output)
+        assert data["skills"]["total"] == 0
+
+    def test_overview_no_buildlog_json_has_empty_render_targets(
+        self, runner, isolated_fs
+    ):
+        """overview --json without buildlog/ has render_targets: []."""
+        result = runner.invoke(main, ["overview", "--json"])
+        data = json.loads(result.output)
+        assert data["render_targets"] == []
+
+    def test_overview_no_buildlog_json_has_message(self, runner, isolated_fs):
+        """overview --json without buildlog/ has informative message."""
+        result = runner.invoke(main, ["overview", "--json"])
+        data = json.loads(result.output)
+        assert "message" in data
+        assert "init" in data["message"].lower()
+
+
+# =============================================================================
+# 3. Graceful Fallback Tests - Status Command
+# =============================================================================
+
+
+class TestStatusFallback:
+    """Tests for buildlog status without buildlog/ directory."""
+
+    def test_status_no_buildlog_returns_zero_exit(self, runner, isolated_fs):
+        """status without buildlog/ returns exit code 0."""
+        result = runner.invoke(main, ["status"])
+        assert result.exit_code == 0
+
+    def test_status_no_buildlog_shows_zero_skills(self, runner, isolated_fs):
+        """status without buildlog/ shows 0 skills."""
+        result = runner.invoke(main, ["status"])
+        assert "0 total" in result.output or "Skills: 0" in result.output
+
+    def test_status_no_buildlog_suggests_init(self, runner, isolated_fs):
+        """status without buildlog/ mentions init."""
+        result = runner.invoke(main, ["status"])
+        assert "init" in result.output.lower()
+
+    def test_status_no_buildlog_json_has_initialized_false(self, runner, isolated_fs):
+        """status --json without buildlog/ has initialized: false."""
+        result = runner.invoke(main, ["status", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["initialized"] is False
+
+    def test_status_no_buildlog_json_has_zero_totals(self, runner, isolated_fs):
+        """status --json without buildlog/ has zero total skills and entries."""
+        result = runner.invoke(main, ["status", "--json"])
+        data = json.loads(result.output)
+        assert data["total_skills"] == 0
+        assert data["total_entries"] == 0
+
+    def test_status_no_buildlog_json_has_empty_skills(self, runner, isolated_fs):
+        """status --json without buildlog/ has empty skills dict."""
+        result = runner.invoke(main, ["status", "--json"])
+        data = json.loads(result.output)
+        assert data["skills"] == {}
+
+    def test_status_no_buildlog_json_has_zero_confidence(self, runner, isolated_fs):
+        """status --json without buildlog/ has zero confidence counts."""
+        result = runner.invoke(main, ["status", "--json"])
+        data = json.loads(result.output)
+        assert data["by_confidence"] == {"high": 0, "medium": 0, "low": 0}
+
+
+# =============================================================================
+# 4. Graceful Fallback Tests - Skills Command
+# =============================================================================
+
+
+class TestSkillsFallback:
+    """Tests for buildlog skills without buildlog/ directory."""
+
+    def test_skills_no_buildlog_returns_zero_exit(self, runner, isolated_fs):
+        """skills without buildlog/ returns exit code 0."""
+        result = runner.invoke(main, ["skills"])
+        assert result.exit_code == 0
+
+    def test_skills_no_buildlog_yaml_shows_empty(self, runner, isolated_fs):
+        """skills without buildlog/ (yaml format) shows empty skills."""
+        result = runner.invoke(main, ["skills"])
+        assert (
+            "skills: {}" in result.output or "not initialized" in result.output.lower()
+        )
+
+    def test_skills_no_buildlog_json_has_initialized_false(self, runner, isolated_fs):
+        """skills --format json without buildlog/ has initialized: false."""
+        result = runner.invoke(main, ["skills", "--format", "json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["initialized"] is False
+
+    def test_skills_no_buildlog_json_has_zero_total(self, runner, isolated_fs):
+        """skills --format json without buildlog/ has total_skills: 0."""
+        result = runner.invoke(main, ["skills", "--format", "json"])
+        data = json.loads(result.output)
+        assert data["total_skills"] == 0
+
+    def test_skills_no_buildlog_json_has_empty_skills(self, runner, isolated_fs):
+        """skills --format json without buildlog/ has empty skills dict."""
+        result = runner.invoke(main, ["skills", "--format", "json"])
+        data = json.loads(result.output)
+        assert data["skills"] == {}
+
+    def test_skills_no_buildlog_markdown_mentions_init(self, runner, isolated_fs):
+        """skills --format markdown without buildlog/ mentions init."""
+        result = runner.invoke(main, ["skills", "--format", "markdown"])
+        assert result.exit_code == 0
+        assert "init" in result.output.lower()
+
+
+# =============================================================================
+# 5. Graceful Fallback Tests - Stats Command
+# =============================================================================
+
+
+class TestStatsFallback:
+    """Tests for buildlog stats without buildlog/ directory."""
+
+    def test_stats_no_buildlog_returns_zero_exit(self, runner, isolated_fs):
+        """stats without buildlog/ returns exit code 0."""
+        result = runner.invoke(main, ["stats"])
+        assert result.exit_code == 0
+
+    def test_stats_no_buildlog_shows_not_initialized(self, runner, isolated_fs):
+        """stats without buildlog/ shows 'not initialized'."""
+        result = runner.invoke(main, ["stats"])
+        assert "not initialized" in result.output.lower()
+
+    def test_stats_no_buildlog_json_has_initialized_false(self, runner, isolated_fs):
+        """stats --json without buildlog/ has initialized: false."""
+        result = runner.invoke(main, ["stats", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["initialized"] is False
+
+    def test_stats_no_buildlog_json_has_zero_entries(self, runner, isolated_fs):
+        """stats --json without buildlog/ has total_entries: 0."""
+        result = runner.invoke(main, ["stats", "--json"])
+        data = json.loads(result.output)
+        assert data["total_entries"] == 0
+
+
+# =============================================================================
+# 6. Graceful Fallback Tests - Diff Command
+# =============================================================================
+
+
+class TestDiffFallback:
+    """Tests for buildlog diff without buildlog/ directory."""
+
+    def test_diff_no_buildlog_returns_zero_exit(self, runner, isolated_fs):
+        """diff without buildlog/ returns exit code 0."""
+        result = runner.invoke(main, ["diff"])
+        assert result.exit_code == 0
+
+    def test_diff_no_buildlog_shows_zero_pending(self, runner, isolated_fs):
+        """diff without buildlog/ shows 'Pending: 0'."""
+        result = runner.invoke(main, ["diff"])
+        assert "Pending: 0" in result.output
+
+    def test_diff_no_buildlog_suggests_init(self, runner, isolated_fs):
+        """diff without buildlog/ mentions init."""
+        result = runner.invoke(main, ["diff"])
+        assert "init" in result.output.lower()
+
+    def test_diff_no_buildlog_json_has_initialized_false(self, runner, isolated_fs):
+        """diff --json without buildlog/ has initialized: false."""
+        result = runner.invoke(main, ["diff", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["initialized"] is False
+
+    def test_diff_no_buildlog_json_has_zero_totals(self, runner, isolated_fs):
+        """diff --json without buildlog/ has zero counts."""
+        result = runner.invoke(main, ["diff", "--json"])
+        data = json.loads(result.output)
+        assert data["total_pending"] == 0
+        assert data["already_promoted"] == 0
+        assert data["already_rejected"] == 0
+
+    def test_diff_no_buildlog_json_has_empty_pending(self, runner, isolated_fs):
+        """diff --json without buildlog/ has empty pending dict."""
+        result = runner.invoke(main, ["diff", "--json"])
+        data = json.loads(result.output)
+        assert data["pending"] == {}
+
+
+# =============================================================================
+# 7. Graceful Fallback Tests - Distill Command
+# =============================================================================
+
+
+class TestDistillFallback:
+    """Tests for buildlog distill without buildlog/ directory."""
+
+    def test_distill_no_buildlog_returns_zero_exit(self, runner, isolated_fs):
+        """distill without buildlog/ returns exit code 0."""
+        result = runner.invoke(main, ["distill"])
+        assert result.exit_code == 0
+
+    def test_distill_no_buildlog_json_has_initialized_false(self, runner, isolated_fs):
+        """distill without buildlog/ (json format) has initialized: false."""
+        result = runner.invoke(main, ["distill"])  # default is json
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["initialized"] is False
+
+    def test_distill_no_buildlog_json_has_empty_patterns(self, runner, isolated_fs):
+        """distill without buildlog/ has empty patterns list."""
+        result = runner.invoke(main, ["distill"])
+        data = json.loads(result.output)
+        assert data["patterns"] == []
+
+    def test_distill_no_buildlog_json_has_zero_statistics(self, runner, isolated_fs):
+        """distill without buildlog/ has zero statistics."""
+        result = runner.invoke(main, ["distill"])
+        data = json.loads(result.output)
+        assert data["statistics"]["total_patterns"] == 0
+        assert data["statistics"]["total_entries"] == 0
+
+    def test_distill_no_buildlog_yaml_mentions_init(self, runner, isolated_fs):
+        """distill --format yaml without buildlog/ mentions init."""
+        result = runner.invoke(main, ["distill", "--format", "yaml"])
+        assert result.exit_code == 0
+        assert "not initialized" in result.output.lower()
+
+
+# =============================================================================
+# 8. Commands That Should Still Work Without Init
+# =============================================================================
+
+
+class TestCommandsWithoutInit:
+    """Tests for commands that should work without buildlog init."""
+
+    def test_gauntlet_list_works_without_init(self, runner, isolated_fs):
+        """gauntlet list works without buildlog/ (uses package data)."""
+        result = runner.invoke(main, ["gauntlet", "list"])
+        # Should not error - uses bundled personas
+        assert result.exit_code == 0 or "No seed" in result.output
+
+    def test_mcp_test_works_without_init(self, runner, isolated_fs):
+        """mcp-test works without buildlog/ (tests package installation)."""
+        result = runner.invoke(main, ["mcp-test"])
+        # Should work - tests the package, not the project
+        assert "tools registered" in result.output or result.exit_code in [0, 1]
+
+    def test_version_works_without_init(self, runner, isolated_fs):
+        """--version works without buildlog/."""
+        result = runner.invoke(main, ["--version"])
+        assert result.exit_code == 0
+
+    def test_help_works_without_init(self, runner, isolated_fs):
+        """--help works without buildlog/."""
+        result = runner.invoke(main, ["--help"])
+        assert result.exit_code == 0
+
+
+# =============================================================================
+# 9. Edge Cases and Error Handling
+# =============================================================================
+
+
+class TestEdgeCases:
+    """Edge cases and error handling tests."""
+
+    def test_overview_with_empty_buildlog_dir(self, runner, isolated_fs):
+        """overview with empty buildlog/ directory works."""
+        Path("buildlog").mkdir()
+        result = runner.invoke(main, ["overview"])
+        assert result.exit_code == 0
+        assert "Entries:     0" in result.output
+
+    def test_status_with_empty_buildlog_dir(self, runner, isolated_fs):
+        """status with empty buildlog/ directory works."""
+        Path("buildlog").mkdir()
+        Path("buildlog/.buildlog").mkdir(parents=True)
+        result = runner.invoke(main, ["status"])
+        assert result.exit_code == 0
+
+    def test_global_mcp_permission_denied(self, runner, mock_home):
+        """--global handles permission denied gracefully."""
+        # Make home read-only
+        (mock_home / ".claude").mkdir()
+        os.chmod(mock_home / ".claude", 0o444)
+
+        try:
+            result = runner.invoke(main, ["init-mcp", "--global"])
+            # Should handle error gracefully
+            assert (
+                "could not register" in result.output.lower() or result.exit_code == 0
+            )
+        finally:
+            os.chmod(mock_home / ".claude", 0o755)
+
+    def test_initialized_true_when_buildlog_exists(self, runner, isolated_fs):
+        """overview --json has initialized: true when buildlog/ exists."""
+        Path("buildlog").mkdir()
+        Path("buildlog/.buildlog").mkdir()
+        result = runner.invoke(main, ["overview", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["initialized"] is True
+
+
+# =============================================================================
+# 10. Integration Tests
+# =============================================================================
+
+
+class TestGlobalWorkflowIntegration:
+    """Integration tests for the full global always-on workflow."""
+
+    def test_full_global_setup_workflow(self, runner, mock_home, isolated_fs):
+        """Test complete global setup workflow."""
+        # Step 1: Register MCP globally
+        result = runner.invoke(main, ["init-mcp", "--global"])
+        assert result.exit_code == 0
+        assert (mock_home / ".claude" / "settings.json").exists()
+
+        # Step 2: Overview should work (shows uninitialized)
+        result = runner.invoke(main, ["overview"])
+        assert result.exit_code == 0
+        assert "not initialized" in result.output.lower()
+
+        # Step 3: Gauntlet should work (uses package data)
+        result = runner.invoke(main, ["gauntlet", "list"])
+        assert result.exit_code == 0 or "No seed" in result.output
+
+    def test_local_then_global_setup(self, runner, mock_home, isolated_fs):
+        """Local init doesn't interfere with global registration."""
+        # Local init
+        result = runner.invoke(main, ["init", "--defaults"])
+        assert Path("buildlog").exists()
+
+        # Global MCP registration
+        result = runner.invoke(main, ["init-mcp", "--global"])
+        assert result.exit_code == 0
+
+        # Both should exist
+        assert Path(".claude/settings.json").exists()
+        assert (mock_home / ".claude" / "settings.json").exists()
+
+    def test_json_output_consistency(self, runner, isolated_fs):
+        """All fallback JSON outputs have consistent structure."""
+        commands = [
+            ["overview", "--json"],
+            ["status", "--json"],
+            ["diff", "--json"],
+            ["distill"],  # default is json
+            ["stats", "--json"],
+        ]
+
+        for cmd in commands:
+            result = runner.invoke(main, cmd)
+            assert result.exit_code == 0, f"Command {cmd} failed"
+            data = json.loads(result.output)
+            assert "initialized" in data, f"Command {cmd} missing 'initialized' key"
+            assert (
+                data["initialized"] is False
+            ), f"Command {cmd} should show initialized=false"


### PR DESCRIPTION
Merges the global always-on changes from #80 that were merged to feat/mcp-full-parity.

This brings in:
- `buildlog init-mcp --global` for ~/.claude/settings.json registration
- Graceful fallbacks for all read commands when buildlog/ missing
- 58 new tests
- docs/plans/global-always-on.md

All 828 tests passing.