### PR TITLE
feat: --global writes usage instructions to ~/.claude/CLAUDE.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,28 +104,34 @@ The roadmap: contextual bandits (now) -> richer policy models -> longer-horizon 
 
 ## Installation
 
-### Quick start
+### Always-On Mode (recommended)
+
+We run buildlog as an **ambient data capture layer** across all projects. One command, works everywhere:
+
+```bash
+pipx install buildlog         # or: uv tool install buildlog
+buildlog init-mcp --global    # registers MCP + writes instructions to ~/.claude/CLAUDE.md
+```
+
+That's it. Claude Code now has all 29 buildlog tools **and knows how to use them** in every project you open. No per-project setup needed.
+
+The `--global` flag:
+- Registers the MCP server in `~/.claude/settings.json`
+- Creates `~/.claude/CLAUDE.md` with usage instructions so Claude proactively uses buildlog
+- Works immediately in any repo, even without a local `buildlog/` directory
+
+This is how we use buildlog ourselves: always on, capturing structured trajectories from every session, feeding downstream systems that generate engineering logs, courses, and content.
+
+### Per-project setup
+
+If you prefer explicit per-project control:
 
 ```bash
 pip install buildlog          # MCP server included by default
-buildlog init --defaults      # scaffold project, register MCP, update CLAUDE.md
+buildlog init --defaults      # scaffold buildlog/, register MCP, update CLAUDE.md
 ```
 
-That's it. Claude Code will now have access to all 29 buildlog tools.
-
-### Global install (recommended)
-
-```bash
-uv tool install buildlog   # or: pipx install buildlog
-```
-
-This puts `buildlog` and `buildlog-mcp` on your PATH. Works from any directory.
-
-### Per-project (virtual environment)
-
-```bash
-uv pip install buildlog    # or: pip install buildlog
-```
+This creates a `buildlog/` directory with templates and configures Claude Code for that specific project.
 
 ### For JS/TS projects
 
@@ -133,16 +139,12 @@ uv pip install buildlog    # or: pip install buildlog
 npx @peleke.s/buildlog init
 ```
 
-### MCP server for Claude Code
-
-`buildlog init` auto-registers the MCP server. For existing projects:
+### Verify installation
 
 ```bash
-buildlog init-mcp          # register MCP in .claude/settings.json
 buildlog mcp-test          # verify all 29 tools are registered
+buildlog overview          # check project state (works without init in global mode)
 ```
-
-This exposes buildlog tools (seeds, skills, experiments, gauntlet, bandit status) to any Claude Code session.
 
 ## Quick Start
 

--- a/src/buildlog/cli.py
+++ b/src/buildlog/cli.py
@@ -165,7 +165,7 @@ def _init_mcp(settings_path: Path | None = None, global_mode: bool = False) -> N
 
     Args:
         settings_path: Path to settings.json. Defaults to .claude/settings.json
-        global_mode: If True, display global-specific messaging
+        global_mode: If True, also writes usage instructions to ~/.claude/CLAUDE.md
     """
     import json as json_module
 
@@ -190,19 +190,55 @@ def _init_mcp(settings_path: Path | None = None, global_mode: bool = False) -> N
         if "mcpServers" not in data:
             data["mcpServers"] = {}
 
-        if "buildlog" in data["mcpServers"]:
+        mcp_already_registered = "buildlog" in data["mcpServers"]
+
+        if not mcp_already_registered:
+            data["mcpServers"]["buildlog"] = {"command": "buildlog-mcp", "args": []}
+            settings_path.parent.mkdir(parents=True, exist_ok=True)
+            settings_path.write_text(json_module.dumps(data, indent=2) + "\n")
+            click.echo(f"Registered buildlog MCP server in {location}")
+        else:
             click.echo(f"buildlog MCP server already registered in {location}")
-            return
 
-        data["mcpServers"]["buildlog"] = {"command": "buildlog-mcp", "args": []}
-
-        settings_path.parent.mkdir(parents=True, exist_ok=True)
-        settings_path.write_text(json_module.dumps(data, indent=2) + "\n")
-        click.echo(f"Registered buildlog MCP server in {location}")
+        # In global mode, also write/update ~/.claude/CLAUDE.md with usage instructions
         if global_mode:
-            click.echo("Claude Code now has access to buildlog tools in all projects.")
+            _init_global_claude_md(settings_path.parent)
+            click.echo(
+                "Claude Code now has buildlog tools + instructions in all projects."
+            )
+
     except Exception as e:
         click.echo(f"Warning: could not register MCP server: {e}", err=True)
+
+
+def _init_global_claude_md(claude_dir: Path) -> None:
+    """Write buildlog usage instructions to ~/.claude/CLAUDE.md.
+
+    Creates or appends to the global CLAUDE.md so Claude knows how to use
+    buildlog tools automatically in any project.
+    """
+    from buildlog.constants import CLAUDE_MD_GLOBAL_SECTION
+
+    claude_md_path = claude_dir / "CLAUDE.md"
+
+    try:
+        if claude_md_path.exists():
+            content = claude_md_path.read_text()
+            # Check if buildlog section already exists
+            if "## buildlog" in content:
+                click.echo("buildlog instructions already in ~/.claude/CLAUDE.md")
+                return
+            # Append to existing file
+            with open(claude_md_path, "a") as f:
+                f.write(CLAUDE_MD_GLOBAL_SECTION)
+            click.echo("Added buildlog instructions to ~/.claude/CLAUDE.md")
+        else:
+            # Create new file with header
+            header = "# Global Claude Instructions\n\nThese instructions apply to all projects.\n"
+            claude_md_path.write_text(header + CLAUDE_MD_GLOBAL_SECTION)
+            click.echo("Created ~/.claude/CLAUDE.md with buildlog instructions")
+    except Exception as e:
+        click.echo(f"Warning: could not write CLAUDE.md: {e}", err=True)
 
 
 @main.command("init-mcp")

--- a/src/buildlog/constants.py
+++ b/src/buildlog/constants.py
@@ -1,5 +1,44 @@
 """Shared constants for buildlog, including the CLAUDE.md integration section."""
 
+# Shorter version for global ~/.claude/CLAUDE.md - focused on "always on" usage
+CLAUDE_MD_GLOBAL_SECTION = """
+## buildlog (Always On)
+
+buildlog is your ambient data capture layer. It runs in ALL projects via MCP.
+Use these tools to track work, extract learnings, and feed downstream systems.
+
+### Core Loop (use after every significant commit)
+
+1. `buildlog_overview()` — check project state
+2. `buildlog_commit(message="...")` — git commit with auto entry logging
+3. `buildlog_gauntlet_rules()` + review + `buildlog_gauntlet_issues([...])` — run gauntlet
+4. `buildlog_log_reward(outcome="accepted")` — close the feedback loop
+
+### Key Tools
+
+| Tool | When to Use |
+|------|-------------|
+| `buildlog_overview()` | Start of session, check state |
+| `buildlog_commit(message)` | Wrap git commits with logging |
+| `buildlog_entry_new(slug)` | Create journal entry |
+| `buildlog_gauntlet_rules()` | Load reviewer personas |
+| `buildlog_gauntlet_issues(issues)` | Process review findings |
+| `buildlog_log_reward(outcome)` | Feedback after approval |
+| `buildlog_skills()` | Extract patterns from entries |
+| `buildlog_status()` | See extracted skills |
+| `buildlog_promote(skill_ids)` | Surface to agent rules |
+
+### Outputs (ambient capture for downstream)
+
+- Journal entries: `buildlog/*.md`
+- Reward signals: `buildlog/.buildlog/reward_events.jsonl`
+- Extracted skills: `buildlog/.buildlog/promoted.json`
+- Review learnings: `buildlog/.buildlog/review_learnings.json`
+
+This data feeds automated content generation, engineering logs, and learning systems.
+"""
+
+# Full version for per-project CLAUDE.md - comprehensive reference
 CLAUDE_MD_BUILDLOG_SECTION = """
 ## buildlog Integration
 

--- a/tests/test_global_always_on.py
+++ b/tests/test_global_always_on.py
@@ -145,6 +145,134 @@ class TestInitMcpGlobal:
 
 
 # =============================================================================
+# 1b. Global CLAUDE.md Tests
+# =============================================================================
+
+
+class TestGlobalClaudeMd:
+    """Tests for ~/.claude/CLAUDE.md creation with --global flag."""
+
+    def test_global_creates_claude_md(self, runner, mock_home):
+        """--global creates ~/.claude/CLAUDE.md with instructions."""
+        result = runner.invoke(main, ["init-mcp", "--global"])
+        assert result.exit_code == 0
+
+        claude_md = mock_home / ".claude" / "CLAUDE.md"
+        assert claude_md.exists()
+
+    def test_global_claude_md_has_buildlog_section(self, runner, mock_home):
+        """--global CLAUDE.md contains buildlog section."""
+        runner.invoke(main, ["init-mcp", "--global"])
+
+        claude_md = mock_home / ".claude" / "CLAUDE.md"
+        content = claude_md.read_text()
+        assert "## buildlog" in content
+
+    def test_global_claude_md_has_always_on_header(self, runner, mock_home):
+        """--global CLAUDE.md mentions 'Always On'."""
+        runner.invoke(main, ["init-mcp", "--global"])
+
+        claude_md = mock_home / ".claude" / "CLAUDE.md"
+        content = claude_md.read_text()
+        assert "Always On" in content
+
+    def test_global_claude_md_has_tool_instructions(self, runner, mock_home):
+        """--global CLAUDE.md contains key tool instructions."""
+        runner.invoke(main, ["init-mcp", "--global"])
+
+        claude_md = mock_home / ".claude" / "CLAUDE.md"
+        content = claude_md.read_text()
+        # Check for key tools
+        assert "buildlog_overview" in content
+        assert "buildlog_commit" in content
+        assert "buildlog_gauntlet" in content
+        assert "buildlog_log_reward" in content
+
+    def test_global_claude_md_has_core_loop(self, runner, mock_home):
+        """--global CLAUDE.md contains the core loop workflow."""
+        runner.invoke(main, ["init-mcp", "--global"])
+
+        claude_md = mock_home / ".claude" / "CLAUDE.md"
+        content = claude_md.read_text()
+        assert (
+            "Core Loop" in content
+            or "after every significant commit" in content.lower()
+        )
+
+    def test_global_claude_md_mentions_downstream(self, runner, mock_home):
+        """--global CLAUDE.md mentions downstream systems."""
+        runner.invoke(main, ["init-mcp", "--global"])
+
+        claude_md = mock_home / ".claude" / "CLAUDE.md"
+        content = claude_md.read_text()
+        assert "downstream" in content.lower()
+
+    def test_global_claude_md_preserves_existing_content(self, runner, mock_home):
+        """--global appends to existing CLAUDE.md without overwriting."""
+        claude_dir = mock_home / ".claude"
+        claude_dir.mkdir()
+        existing_content = "# My Custom Instructions\n\nDo things my way.\n"
+        (claude_dir / "CLAUDE.md").write_text(existing_content)
+
+        runner.invoke(main, ["init-mcp", "--global"])
+
+        claude_md = claude_dir / "CLAUDE.md"
+        content = claude_md.read_text()
+        # Original content preserved
+        assert "My Custom Instructions" in content
+        assert "Do things my way" in content
+        # New content appended
+        assert "## buildlog" in content
+
+    def test_global_claude_md_idempotent(self, runner, mock_home):
+        """Running --global twice doesn't duplicate buildlog section."""
+        runner.invoke(main, ["init-mcp", "--global"])
+        runner.invoke(main, ["init-mcp", "--global"])
+
+        claude_md = mock_home / ".claude" / "CLAUDE.md"
+        content = claude_md.read_text()
+        # Should only have one buildlog section
+        assert content.count("## buildlog") == 1
+
+    def test_global_claude_md_output_message(self, runner, mock_home):
+        """--global shows message about CLAUDE.md creation."""
+        result = runner.invoke(main, ["init-mcp", "--global"])
+        assert "CLAUDE.md" in result.output
+
+    def test_global_claude_md_already_exists_message(self, runner, mock_home):
+        """Running --global twice shows 'already in' message for CLAUDE.md."""
+        runner.invoke(main, ["init-mcp", "--global"])
+        result = runner.invoke(main, ["init-mcp", "--global"])
+        assert "already" in result.output.lower()
+
+    def test_global_creates_header_for_new_file(self, runner, mock_home):
+        """New CLAUDE.md has a header explaining it's global instructions."""
+        runner.invoke(main, ["init-mcp", "--global"])
+
+        claude_md = mock_home / ".claude" / "CLAUDE.md"
+        content = claude_md.read_text()
+        assert "Global" in content
+        assert "all projects" in content.lower()
+
+    def test_global_claude_md_has_outputs_section(self, runner, mock_home):
+        """--global CLAUDE.md lists the output files for downstream consumption."""
+        runner.invoke(main, ["init-mcp", "--global"])
+
+        claude_md = mock_home / ".claude" / "CLAUDE.md"
+        content = claude_md.read_text()
+        assert "reward_events.jsonl" in content or "Outputs" in content
+
+    def test_local_mode_does_not_create_global_claude_md(
+        self, runner, mock_home, isolated_fs
+    ):
+        """Local init-mcp (without --global) doesn't touch ~/.claude/CLAUDE.md."""
+        runner.invoke(main, ["init-mcp"])
+
+        global_claude_md = mock_home / ".claude" / "CLAUDE.md"
+        assert not global_claude_md.exists()
+
+
+# =============================================================================
 # 2. Graceful Fallback Tests - Overview Command
 # =============================================================================
 


### PR DESCRIPTION
## Summary

`buildlog init-mcp --global` now does two things:
1. Registers MCP server in `~/.claude/settings.json` 
2. **Creates/updates `~/.claude/CLAUDE.md` with usage instructions**

This means Claude **proactively uses buildlog tools** without being told.

## What's in ~/.claude/CLAUDE.md

```markdown
## buildlog (Always On)

buildlog is your ambient data capture layer. It runs in ALL projects via MCP.

### Core Loop (use after every significant commit)
1. buildlog_overview() — check project state
2. buildlog_commit(message="...") — git commit with auto entry logging
3. buildlog_gauntlet_rules() + review + buildlog_gauntlet_issues([...])
4. buildlog_log_reward(outcome="accepted") — close the feedback loop

### Key Tools
| Tool | When to Use |
|------|-------------|
| buildlog_overview() | Start of session |
| buildlog_commit(message) | Wrap git commits |
...
```

## README Update

Updated Installation section to prominently feature "Always-On Mode":

> We run buildlog as an **ambient data capture layer** across all projects. One command, works everywhere.

## Tests

13 new tests for global CLAUDE.md functionality:
- Creates ~/.claude/CLAUDE.md
- Has buildlog section with tools
- Has core loop workflow
- Mentions downstream systems
- Preserves existing content
- Idempotent (doesn't duplicate)
- Local mode doesn't touch global

All 841 tests passing.

## Usage

```bash
pipx install buildlog
buildlog init-mcp --global
# Done. Claude now knows to use buildlog in every project.
```