### PR TITLE
fix(ci): add npm environment for OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -116,6 +116,9 @@ jobs:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     needs: publish-pypi
     runs-on: ubuntu-latest
+    environment:
+      name: npm
+      url: https://www.npmjs.com/package/@peleke.s/buildlog
     permissions:
       id-token: write
     defaults:


### PR DESCRIPTION
## Summary
- Adds `environment: name: npm` to the publish-npm job in the release workflow
- Required for npm OIDC trusted publishing to work (matches the trusted publisher configured on npmjs.org)

## Context
The v0.10.0 and v0.10.1 releases failed npm publishing with a 404 error because the workflow was missing the environment configuration that npm's OIDC trusted publisher expects.

## Test plan
- [ ] Merge this PR
- [ ] Create new tag (v0.10.2 or re-tag) to trigger workflow
- [ ] Verify npm publish succeeds with OIDC authentication

🤖 Generated with [Claude Code](https://claude.com/claude-code)