### PR TITLE
chore: release v0.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.10.2] - 2026-02-04
+
+### Fixed
+- npm OIDC trusted publishing: added missing `environment` configuration to workflow
+
 ## [0.10.1] - 2026-02-03
 
 ### Added
@@ -158,7 +163,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   - `buildlog_status`, `buildlog_promote`, `buildlog_reject`, `buildlog_diff`
 - **Embedding Backends**: Token-based, sentence-transformers, OpenAI
 
-[Unreleased]: https://github.com/Peleke/buildlog-template/compare/v0.10.1...HEAD
+[Unreleased]: https://github.com/Peleke/buildlog-template/compare/v0.10.2...HEAD
+[0.10.2]: https://github.com/Peleke/buildlog-template/compare/v0.10.1...v0.10.2
 [0.10.1]: https://github.com/Peleke/buildlog-template/compare/v0.10.0...v0.10.1
 [0.10.0]: https://github.com/Peleke/buildlog-template/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/Peleke/buildlog-template/compare/v0.8.0...v0.9.0

--- a/packages/buildlog-npm/package.json
+++ b/packages/buildlog-npm/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Engineering notebook for AI-assisted development. Capture your work as publishable content.",
   "license": "MIT",
   "repository": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "buildlog"
-version = "0.10.1"
+version = "0.10.2"
 description = "Engineering notebook for AI-assisted development"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Version bump to 0.10.2
- Picks up the npm OIDC trusted publishing fix from #85

This release exists specifically to get the workflow fix into a tagged release so npm publish works.

## Test plan
- [ ] Merge, tag v0.10.2, push tag
- [ ] Verify PyPI publish succeeds
- [ ] Verify npm publish succeeds with OIDC
- [ ] Verify GitHub release is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)