### PR TITLE
chore: release v0.10.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.10.3] - 2026-02-04
+
+### Fixed
+- `buildlog init-mcp --global` now writes to `~/.claude.json` (correct location for Claude Code MCP servers)
+- Previously wrote to `~/.claude/settings.json` which Claude Code doesn't read for MCP configs
+
 ## [0.10.2] - 2026-02-04
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "buildlog"
-version = "0.10.2"
+version = "0.10.3"
 description = "Engineering notebook for AI-assisted development"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

Release v0.10.3 with fix for MCP config location.

### Fixed
- `buildlog init-mcp --global` now writes to `~/.claude.json` (correct location for Claude Code MCP servers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)