### PR TITLE
feat(init-mcp): add permission prompts with -y flag

### DIFF
--- a/src/buildlog/cli.py
+++ b/src/buildlog/cli.py
@@ -143,7 +143,7 @@ def init(no_claude_md: bool, no_mcp: bool, defaults: bool):
 
     # Register MCP server unless opted out
     if not no_mcp:
-        _init_mcp()
+        _init_mcp(skip_confirm=defaults)
 
     click.echo("\n✓ buildlog initialized!")
     click.echo()
@@ -160,12 +160,17 @@ def init(no_claude_md: bool, no_mcp: bool, defaults: bool):
     click.echo("Start now: buildlog new my-first-task --quick")
 
 
-def _init_mcp(settings_path: Path | None = None, global_mode: bool = False) -> None:
+def _init_mcp(
+    settings_path: Path | None = None,
+    global_mode: bool = False,
+    skip_confirm: bool = False,
+) -> None:
     """Register buildlog as an MCP server in settings.json.
 
     Args:
         settings_path: Path to settings.json. Defaults to .claude/settings.json
         global_mode: If True, also writes usage instructions to ~/.claude/CLAUDE.md
+        skip_confirm: If True, skip confirmation prompts (non-interactive mode)
     """
     import json as json_module
 
@@ -204,6 +209,13 @@ def _init_mcp(settings_path: Path | None = None, global_mode: bool = False) -> N
         if current_config == correct_config:
             click.echo(f"buildlog MCP server already registered in {location}")
         else:
+            # Prompt for confirmation before modifying disk
+            if not skip_confirm:
+                action = "Update" if current_config else "Create/modify"
+                if not click.confirm(f"{action} {location}?"):
+                    click.echo("Aborted.")
+                    return
+
             data["mcpServers"]["buildlog"] = correct_config
             if not global_mode:
                 settings_path.parent.mkdir(parents=True, exist_ok=True)
@@ -215,7 +227,7 @@ def _init_mcp(settings_path: Path | None = None, global_mode: bool = False) -> N
 
         # In global mode, also write/update ~/.claude/CLAUDE.md with usage instructions
         if global_mode:
-            _init_global_claude_md(Path.home() / ".claude")
+            _init_global_claude_md(Path.home() / ".claude", skip_confirm=skip_confirm)
             click.echo(
                 "Claude Code now has buildlog tools + instructions in all projects."
             )
@@ -224,11 +236,15 @@ def _init_mcp(settings_path: Path | None = None, global_mode: bool = False) -> N
         click.echo(f"Warning: could not register MCP server: {e}", err=True)
 
 
-def _init_global_claude_md(claude_dir: Path) -> None:
+def _init_global_claude_md(claude_dir: Path, skip_confirm: bool = False) -> None:
     """Write buildlog usage instructions to ~/.claude/CLAUDE.md.
 
     Creates or appends to the global CLAUDE.md so Claude knows how to use
     buildlog tools automatically in any project.
+
+    Args:
+        claude_dir: Path to ~/.claude directory
+        skip_confirm: If True, skip confirmation prompts (non-interactive mode)
     """
     from buildlog.constants import CLAUDE_MD_GLOBAL_SECTION
 
@@ -241,11 +257,25 @@ def _init_global_claude_md(claude_dir: Path) -> None:
             if "## buildlog" in content:
                 click.echo("buildlog instructions already in ~/.claude/CLAUDE.md")
                 return
+            # Prompt for confirmation before modifying disk
+            if not skip_confirm:
+                if not click.confirm(
+                    "Append buildlog instructions to ~/.claude/CLAUDE.md?"
+                ):
+                    click.echo("Skipped CLAUDE.md update.")
+                    return
             # Append to existing file
             with open(claude_md_path, "a") as f:
                 f.write(CLAUDE_MD_GLOBAL_SECTION)
             click.echo("Added buildlog instructions to ~/.claude/CLAUDE.md")
         else:
+            # Prompt for confirmation before creating new file
+            if not skip_confirm:
+                if not click.confirm(
+                    "Create ~/.claude/CLAUDE.md with buildlog instructions?"
+                ):
+                    click.echo("Skipped CLAUDE.md creation.")
+                    return
             # Create new file with header
             claude_dir.mkdir(parents=True, exist_ok=True)
             header = "# Global Claude Instructions\n\nThese instructions apply to all projects.\n"
@@ -262,7 +292,13 @@ def _init_global_claude_md(claude_dir: Path) -> None:
     is_flag=True,
     help="Register globally in ~/.claude.json (works in any project)",
 )
-def init_mcp(global_: bool):
+@click.option(
+    "-y",
+    "--yes",
+    is_flag=True,
+    help="Skip confirmation prompts (non-interactive mode)",
+)
+def init_mcp(global_: bool, yes: bool):
     """Register buildlog as an MCP server for Claude Code.
 
     Creates or updates .claude/settings.json with the buildlog MCP
@@ -275,12 +311,13 @@ def init_mcp(global_: bool):
 
         buildlog init-mcp              # local (current project)
         buildlog init-mcp --global     # global (all projects)
+        buildlog init-mcp --global -y  # global, skip prompts
     """
     if global_:
         settings_path = Path.home() / ".claude.json"
-        _init_mcp(settings_path=settings_path, global_mode=True)
+        _init_mcp(settings_path=settings_path, global_mode=True, skip_confirm=yes)
     else:
-        _init_mcp()
+        _init_mcp(skip_confirm=yes)
 
 
 @main.command("mcp-test")

--- a/tests/test_global_always_on.py
+++ b/tests/test_global_always_on.py
@@ -54,13 +54,13 @@ class TestInitMcpGlobal:
 
     def test_global_flag_creates_claude_json(self, runner, mock_home):
         """--global creates ~/.claude.json file."""
-        result = runner.invoke(main, ["init-mcp", "--global"])
+        result = runner.invoke(main, ["init-mcp", "--global", "-y"])
         assert result.exit_code == 0
         assert (mock_home / ".claude.json").exists()
 
     def test_global_flag_writes_correct_path(self, runner, mock_home):
         """--global writes to ~/.claude.json, not local."""
-        result = runner.invoke(main, ["init-mcp", "--global"])
+        result = runner.invoke(main, ["init-mcp", "--global", "-y"])
         assert result.exit_code == 0
 
         # Global file should exist
@@ -73,7 +73,7 @@ class TestInitMcpGlobal:
 
     def test_global_flag_correct_mcp_config(self, runner, mock_home):
         """--global writes correct buildlog MCP server config."""
-        result = runner.invoke(main, ["init-mcp", "--global"])
+        result = runner.invoke(main, ["init-mcp", "--global", "-y"])
         assert result.exit_code == 0
 
         settings = json.loads((mock_home / ".claude.json").read_text())
@@ -91,7 +91,7 @@ class TestInitMcpGlobal:
         }
         (mock_home / ".claude.json").write_text(json.dumps(existing))
 
-        result = runner.invoke(main, ["init-mcp", "--global"])
+        result = runner.invoke(main, ["init-mcp", "--global", "-y"])
         assert result.exit_code == 0
 
         settings = json.loads((mock_home / ".claude.json").read_text())
@@ -100,8 +100,8 @@ class TestInitMcpGlobal:
 
     def test_global_flag_idempotent(self, runner, mock_home):
         """Running --global twice doesn't duplicate entry."""
-        runner.invoke(main, ["init-mcp", "--global"])
-        result = runner.invoke(main, ["init-mcp", "--global"])
+        runner.invoke(main, ["init-mcp", "--global", "-y"])
+        result = runner.invoke(main, ["init-mcp", "--global", "-y"])
 
         assert result.exit_code == 0
         assert "already registered" in result.output
@@ -111,23 +111,23 @@ class TestInitMcpGlobal:
 
     def test_global_flag_shows_global_path_in_output(self, runner, mock_home):
         """--global output mentions ~/.claude.json."""
-        result = runner.invoke(main, ["init-mcp", "--global"])
+        result = runner.invoke(main, ["init-mcp", "--global", "-y"])
         assert "~/.claude.json" in result.output
 
     def test_global_flag_shows_all_projects_message(self, runner, mock_home):
         """--global output mentions it works in all projects."""
-        result = runner.invoke(main, ["init-mcp", "--global"])
+        result = runner.invoke(main, ["init-mcp", "--global", "-y"])
         assert "all projects" in result.output.lower()
 
     def test_local_mode_default(self, runner, isolated_fs):
         """Without --global, writes to local .claude/settings.json."""
-        result = runner.invoke(main, ["init-mcp"])
+        result = runner.invoke(main, ["init-mcp", "-y"])
         assert result.exit_code == 0
         assert Path(".claude/settings.json").exists()
 
     def test_local_mode_shows_local_path(self, runner, isolated_fs):
         """Local mode output mentions .claude/settings.json."""
-        result = runner.invoke(main, ["init-mcp"])
+        result = runner.invoke(main, ["init-mcp", "-y"])
         assert ".claude/settings.json" in result.output
         assert "~/.claude" not in result.output
 
@@ -135,9 +135,30 @@ class TestInitMcpGlobal:
         """--global handles malformed existing .claude.json gracefully."""
         (mock_home / ".claude.json").write_text("{ invalid json }")
 
-        result = runner.invoke(main, ["init-mcp", "--global"])
+        result = runner.invoke(main, ["init-mcp", "--global", "-y"])
         assert result.exit_code == 0
         assert "malformed" in result.output.lower()
+
+    def test_interactive_prompts_for_confirmation(self, runner, mock_home):
+        """Without -y, prompts for confirmation."""
+        result = runner.invoke(main, ["init-mcp", "--global"], input="y\ny\n")
+        assert result.exit_code == 0
+        assert (mock_home / ".claude.json").exists()
+
+    def test_interactive_abort_on_no(self, runner, mock_home):
+        """User can abort by answering 'n' to confirmation."""
+        result = runner.invoke(main, ["init-mcp", "--global"], input="n\n")
+        assert result.exit_code == 0
+        assert "Aborted" in result.output
+        assert not (mock_home / ".claude.json").exists()
+
+    def test_yes_flag_skips_confirmation(self, runner, mock_home):
+        """-y flag skips confirmation prompts."""
+        result = runner.invoke(main, ["init-mcp", "--global", "-y"])
+        assert result.exit_code == 0
+        # Should not contain any confirmation text
+        assert "?" not in result.output
+        assert (mock_home / ".claude.json").exists()
 
 
 # =============================================================================
@@ -150,7 +171,7 @@ class TestGlobalClaudeMd:
 
     def test_global_creates_claude_md(self, runner, mock_home):
         """--global creates ~/.claude/CLAUDE.md with instructions."""
-        result = runner.invoke(main, ["init-mcp", "--global"])
+        result = runner.invoke(main, ["init-mcp", "--global", "-y"])
         assert result.exit_code == 0
 
         claude_md = mock_home / ".claude" / "CLAUDE.md"
@@ -158,7 +179,7 @@ class TestGlobalClaudeMd:
 
     def test_global_claude_md_has_buildlog_section(self, runner, mock_home):
         """--global CLAUDE.md contains buildlog section."""
-        runner.invoke(main, ["init-mcp", "--global"])
+        runner.invoke(main, ["init-mcp", "--global", "-y"])
 
         claude_md = mock_home / ".claude" / "CLAUDE.md"
         content = claude_md.read_text()
@@ -166,7 +187,7 @@ class TestGlobalClaudeMd:
 
     def test_global_claude_md_has_always_on_header(self, runner, mock_home):
         """--global CLAUDE.md mentions 'Always On'."""
-        runner.invoke(main, ["init-mcp", "--global"])
+        runner.invoke(main, ["init-mcp", "--global", "-y"])
 
         claude_md = mock_home / ".claude" / "CLAUDE.md"
         content = claude_md.read_text()
@@ -174,7 +195,7 @@ class TestGlobalClaudeMd:
 
     def test_global_claude_md_has_tool_instructions(self, runner, mock_home):
         """--global CLAUDE.md contains key tool instructions."""
-        runner.invoke(main, ["init-mcp", "--global"])
+        runner.invoke(main, ["init-mcp", "--global", "-y"])
 
         claude_md = mock_home / ".claude" / "CLAUDE.md"
         content = claude_md.read_text()
@@ -186,7 +207,7 @@ class TestGlobalClaudeMd:
 
     def test_global_claude_md_has_core_loop(self, runner, mock_home):
         """--global CLAUDE.md contains the core loop workflow."""
-        runner.invoke(main, ["init-mcp", "--global"])
+        runner.invoke(main, ["init-mcp", "--global", "-y"])
 
         claude_md = mock_home / ".claude" / "CLAUDE.md"
         content = claude_md.read_text()
@@ -197,7 +218,7 @@ class TestGlobalClaudeMd:
 
     def test_global_claude_md_mentions_downstream(self, runner, mock_home):
         """--global CLAUDE.md mentions downstream systems."""
-        runner.invoke(main, ["init-mcp", "--global"])
+        runner.invoke(main, ["init-mcp", "--global", "-y"])
 
         claude_md = mock_home / ".claude" / "CLAUDE.md"
         content = claude_md.read_text()
@@ -210,7 +231,7 @@ class TestGlobalClaudeMd:
         existing_content = "# My Custom Instructions\n\nDo things my way.\n"
         (claude_dir / "CLAUDE.md").write_text(existing_content)
 
-        runner.invoke(main, ["init-mcp", "--global"])
+        runner.invoke(main, ["init-mcp", "--global", "-y"])
 
         claude_md = claude_dir / "CLAUDE.md"
         content = claude_md.read_text()
@@ -222,8 +243,8 @@ class TestGlobalClaudeMd:
 
     def test_global_claude_md_idempotent(self, runner, mock_home):
         """Running --global twice doesn't duplicate buildlog section."""
-        runner.invoke(main, ["init-mcp", "--global"])
-        runner.invoke(main, ["init-mcp", "--global"])
+        runner.invoke(main, ["init-mcp", "--global", "-y"])
+        runner.invoke(main, ["init-mcp", "--global", "-y"])
 
         claude_md = mock_home / ".claude" / "CLAUDE.md"
         content = claude_md.read_text()
@@ -232,18 +253,18 @@ class TestGlobalClaudeMd:
 
     def test_global_claude_md_output_message(self, runner, mock_home):
         """--global shows message about CLAUDE.md creation."""
-        result = runner.invoke(main, ["init-mcp", "--global"])
+        result = runner.invoke(main, ["init-mcp", "--global", "-y"])
         assert "CLAUDE.md" in result.output
 
     def test_global_claude_md_already_exists_message(self, runner, mock_home):
         """Running --global twice shows 'already in' message for CLAUDE.md."""
-        runner.invoke(main, ["init-mcp", "--global"])
-        result = runner.invoke(main, ["init-mcp", "--global"])
+        runner.invoke(main, ["init-mcp", "--global", "-y"])
+        result = runner.invoke(main, ["init-mcp", "--global", "-y"])
         assert "already" in result.output.lower()
 
     def test_global_creates_header_for_new_file(self, runner, mock_home):
         """New CLAUDE.md has a header explaining it's global instructions."""
-        runner.invoke(main, ["init-mcp", "--global"])
+        runner.invoke(main, ["init-mcp", "--global", "-y"])
 
         claude_md = mock_home / ".claude" / "CLAUDE.md"
         content = claude_md.read_text()
@@ -252,7 +273,7 @@ class TestGlobalClaudeMd:
 
     def test_global_claude_md_has_outputs_section(self, runner, mock_home):
         """--global CLAUDE.md lists the output files for downstream consumption."""
-        runner.invoke(main, ["init-mcp", "--global"])
+        runner.invoke(main, ["init-mcp", "--global", "-y"])
 
         claude_md = mock_home / ".claude" / "CLAUDE.md"
         content = claude_md.read_text()
@@ -604,7 +625,7 @@ class TestEdgeCases:
         os.chmod(mock_home / ".claude.json", 0o444)
 
         try:
-            result = runner.invoke(main, ["init-mcp", "--global"])
+            result = runner.invoke(main, ["init-mcp", "--global", "-y"])
             # Should handle error gracefully (either succeeds because already registered
             # or shows error message)
             assert (
@@ -636,7 +657,7 @@ class TestGlobalWorkflowIntegration:
     def test_full_global_setup_workflow(self, runner, mock_home, isolated_fs):
         """Test complete global setup workflow."""
         # Step 1: Register MCP globally
-        result = runner.invoke(main, ["init-mcp", "--global"])
+        result = runner.invoke(main, ["init-mcp", "--global", "-y"])
         assert result.exit_code == 0
         assert (mock_home / ".claude.json").exists()
 
@@ -656,7 +677,7 @@ class TestGlobalWorkflowIntegration:
         assert Path("buildlog").exists()
 
         # Global MCP registration
-        result = runner.invoke(main, ["init-mcp", "--global"])
+        result = runner.invoke(main, ["init-mcp", "--global", "-y"])
         assert result.exit_code == 0
 
         # Both should exist

--- a/tests/test_init_mcp.py
+++ b/tests/test_init_mcp.py
@@ -17,7 +17,7 @@ class TestInitMcp:
         """Should create .claude/settings.json from scratch."""
         monkeypatch.chdir(tmp_path)
         runner = CliRunner()
-        runner.invoke(main, ["init-mcp"])
+        runner.invoke(main, ["init-mcp", "-y"])
 
         settings = tmp_path / ".claude" / "settings.json"
         assert settings.exists()
@@ -38,7 +38,7 @@ class TestInitMcp:
         (claude_dir / "settings.json").write_text(json.dumps(existing))
 
         runner = CliRunner()
-        runner.invoke(main, ["init-mcp"])
+        runner.invoke(main, ["init-mcp", "-y"])
 
         data = json.loads((claude_dir / "settings.json").read_text())
         assert "buildlog" in data["mcpServers"]
@@ -49,8 +49,8 @@ class TestInitMcp:
         """Running twice should produce same result."""
         monkeypatch.chdir(tmp_path)
         runner = CliRunner()
-        runner.invoke(main, ["init-mcp"])
-        runner.invoke(main, ["init-mcp"])
+        runner.invoke(main, ["init-mcp", "-y"])
+        runner.invoke(main, ["init-mcp", "-y"])
 
         settings = tmp_path / ".claude" / "settings.json"
         data = json.loads(settings.read_text())
@@ -66,7 +66,7 @@ class TestInitMcp:
         (claude_dir / "settings.json").write_text("{invalid json")
 
         runner = CliRunner()
-        result = runner.invoke(main, ["init-mcp"])
+        result = runner.invoke(main, ["init-mcp", "-y"])
         assert "malformed" in result.output or "Warning" in result.output
 
     def test_preserves_non_mcp_keys(self, tmp_path, monkeypatch):
@@ -78,7 +78,7 @@ class TestInitMcp:
         (claude_dir / "settings.json").write_text(json.dumps(existing))
 
         runner = CliRunner()
-        runner.invoke(main, ["init-mcp"])
+        runner.invoke(main, ["init-mcp", "-y"])
 
         data = json.loads((claude_dir / "settings.json").read_text())
         assert data["apiKey"] == "secret"


### PR DESCRIPTION
## Summary

- `init-mcp` now prompts for confirmation before modifying disk
- Added `-y`/`--yes` flag to skip prompts (non-interactive mode)
- `init --defaults` also skips prompts for CI-friendliness

## Test plan

- [x] All 815 tests pass
- [x] New tests for interactive mode (confirm/abort)
- [x] New tests for `-y` flag behavior

## Example

```bash
# Interactive (prompts for confirmation)
buildlog init-mcp --global

# Non-interactive (skips prompts)
buildlog init-mcp --global -y
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)