### PR TITLE
chore: release v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,13 +18,20 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - **Export manifest** — `manifest.json` generated with `exported_at`, `project_id`, and per-table record counts
 - **Rules join table** — `rules.jsonl` maps `buildlog_id` to upstream provenance fields (`source_id`, `source_domain`, `graph_version`, etc.)
 - 30 new tests across seeds, skills, bandit, and export modules (966 total)
+- **B7: Shared directory protocol** — `ingest_pending()` consumer-side ingest from external producers with 7-layer security validation
+- **`buildlog ingest-seeds`** CLI command and `buildlog_ingest_seeds` MCP tool (33 tools total)
+- **Signal log** — append-only JSONL event log for seed ingest observability
+- **Error sidecars** — `.error` JSON files written next to failed seed files
+- **Interop config** — `~/.buildlog/interop.yaml` for multi-source seed ingestion
+- 31 new interop tests (997 total)
+- SVG plots for theory docs (beta distributions, regret curves, Thompson Sampling convergence)
 
 ### Changed
 - Default seed rule category changed from `"security"` to `"general"` (less opinionated default)
 - `_get_seed_rule_ids()` now returns `(set[str], dict[str, float])` tuple with confidence map
 - `ThompsonSamplingBandit.select()` accepts optional `seed_confidence_map` parameter
 - `JsonlExporter.export()` accepts `include_manifest`, `include_rules_join`, `seeds_dir` params
-- Tool count references updated from 31 to 32 across all docs, source, and tests
+- Tool count references updated from 31 to 33 across all docs, source, and tests
 
 ## [0.11.1] - 2026-02-05
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "buildlog"
-version = "0.11.1"
+version = "0.12.0"
 description = "Engineering notebook for AI-assisted development"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Bump version 0.11.1 → 0.12.0
- Update CHANGELOG with B7 shared directory protocol, interop config, signal log, error sidecars, theory plots, and tool count 31→33

## What's in 0.12.0
- Track E: qortex interop (provenance, confidence boosting, import-seed, export expansion)
- B7: shared directory protocol (consumer-side ingest, 7-layer security, signal log)
- `buildlog_ingest_seeds` MCP tool + `ingest-seeds` CLI (33 tools total)
- Interop guide, SVG theory plots, full docs update

🤖 Generated with [Claude Code](https://claude.com/claude-code)