### PR TITLE
fix: resolve 4 gauntlet issues from emissions protocol (#118-#121)

### DIFF
--- a/src/buildlog/emissions/__init__.py
+++ b/src/buildlog/emissions/__init__.py
@@ -20,6 +20,7 @@ import logging
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any
 
 __all__ = [
     "EMISSIONS_DIR",
@@ -43,6 +44,23 @@ class EmissionConfig:
     processed: Path
     failed: Path
     signal_log: Path
+
+
+def _emission_json_serializer(obj: Any) -> Any:
+    """Explicit JSON serializer for emission artifacts.
+
+    Handles known types (datetime, Path) and raises TypeError for
+    truly unknown types, rather than silently converting via str().
+    """
+    if isinstance(obj, datetime):
+        return obj.isoformat()
+    if isinstance(obj, Path):
+        return str(obj)
+    raise TypeError(
+        f"Object of type {type(obj).__name__} is not JSON serializable. "
+        f"Add explicit handling in _emission_json_serializer() or "
+        f"pre-serialize before calling emit_artifact()."
+    )
 
 
 def get_emission_config(base: Path | None = None) -> EmissionConfig:
@@ -87,7 +105,9 @@ def emit_artifact(
         filename = f"{artifact_type}_{project_id}_{ts_str}.json"
         path = cfg.pending / filename
 
-        path.write_text(json.dumps(artifact, indent=2, default=str))
+        path.write_text(
+            json.dumps(artifact, indent=2, default=_emission_json_serializer)
+        )
 
         # Append to signal log
         signal_entry = {

--- a/src/buildlog/emissions/mappers.py
+++ b/src/buildlog/emissions/mappers.py
@@ -260,6 +260,13 @@ def resolution_edges(ctx: EdgeMapperContext) -> MapperOutput:
 # Default registry
 # ---------------------------------------------------------------------------
 
+# NOTE (issue #121): DEFAULT_REGISTRY is intentionally created at module level
+# rather than lazily. The overhead is negligible — each register() call just
+# stores a function reference in a dict and adds a name to a set. There are
+# only 6 mappers and no heavy initialization (no I/O, no network, no large
+# allocations). Lazy initialization would add complexity (thread-safety,
+# first-call latency surprises) for no measurable benefit. Evaluated and
+# accepted on 2026-02-06.
 DEFAULT_REGISTRY = EdgeMapperRegistry()
 DEFAULT_REGISTRY.register("concept_involvement", concept_involvement)
 DEFAULT_REGISTRY.register("rule_challenge", rule_challenge)

--- a/src/buildlog/storage/sqlite.py
+++ b/src/buildlog/storage/sqlite.py
@@ -316,12 +316,23 @@ class SQLiteBackend:
                 ),
             )
         elif resolved == "mistakes":
+            # Serialize list/dict fields to JSON for SQLite TEXT columns
+            related_concepts = record.get("related_concepts")
+            if related_concepts is not None and not isinstance(related_concepts, str):
+                related_concepts = json.dumps(related_concepts)
+
+            relation_to_prior = record.get("relation_to_prior")
+            if relation_to_prior is not None and not isinstance(relation_to_prior, str):
+                relation_to_prior = json.dumps(relation_to_prior)
+
             self.conn.execute(
                 """\
                 INSERT OR REPLACE INTO mistakes
                     (project_id, id, session_id, timestamp, error_class,
-                     description, semantic_hash, was_repeat, corrected_by_rule)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                     description, semantic_hash, was_repeat, corrected_by_rule,
+                     related_concepts, relation_to_prior, resolution_action,
+                     context, severity)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     project_id,
@@ -333,6 +344,11 @@ class SQLiteBackend:
                     record["semantic_hash"],
                     1 if record.get("was_repeat") else 0,
                     record.get("corrected_by_rule"),
+                    related_concepts,
+                    relation_to_prior,
+                    record.get("resolution_action"),
+                    record.get("context"),
+                    record.get("severity"),
                 ),
             )
 

--- a/tests/test_emissions.py
+++ b/tests/test_emissions.py
@@ -766,3 +766,152 @@ class TestMetamorphic:
         types1 = sorted(e["relation_type"] for e in man1["edges"])
         types2 = sorted(e["relation_type"] for e in man2["edges"])
         assert types1 == types2
+
+
+# ============================================================================
+# Part 9: Round-trip property test for enriched Mistake fields via SQLite
+# ============================================================================
+
+
+class TestMistakeSQLiteRoundTrip:
+    """Property test: enriched Mistake fields survive persist → load via SQLite."""
+
+    @given(m=mistake_st())
+    @settings(max_examples=50)
+    def test_round_trip_fidelity(self, m: Mistake):
+        """Persist a random Mistake via SQLite, load it back, verify all fields."""
+        conn = sqlite3.connect(":memory:")
+        conn.row_factory = sqlite3.Row
+        init_schema(conn)
+
+        from buildlog.storage.sqlite import SQLiteBackend
+
+        backend = SQLiteBackend(conn)
+        project_id = "roundtrip-test"
+        backend.ensure_project(project_id, "test", "/tmp/test")
+
+        # Persist
+        backend.append_event(project_id, "mistakes", m.to_dict())
+
+        # Load
+        rows = backend.load_events(project_id, "mistakes")
+        assert len(rows) == 1
+        loaded = Mistake.from_dict(rows[0])
+
+        # Verify every field round-trips
+        assert loaded.id == m.id
+        assert loaded.session_id == m.session_id
+        assert loaded.error_class == m.error_class
+        assert loaded.description == m.description
+        assert loaded.semantic_hash == m.semantic_hash
+        assert loaded.was_repeat == m.was_repeat
+        assert loaded.corrected_by_rule == m.corrected_by_rule
+        assert loaded.related_concepts == m.related_concepts
+        assert loaded.relation_to_prior == m.relation_to_prior
+        assert loaded.resolution_action == m.resolution_action
+        assert loaded.context == m.context
+        assert loaded.severity == m.severity
+
+
+# ============================================================================
+# Part 10: YAML emissions config integration test (disabled_mappers)
+# ============================================================================
+
+
+class TestYAMLEmissionsConfig:
+    """Integration test: YAML config disables individual mappers."""
+
+    def test_disabled_mappers_skipped(self):
+        """Load a YAML config string and verify disabled mappers are not run."""
+        import yaml
+
+        yaml_content = """\
+disabled_mappers:
+  - resolution_edges
+  - concept_involvement
+"""
+        cfg = yaml.safe_load(yaml_content) or {}
+
+        # Build a fresh registry with all 6 mappers
+        reg = EdgeMapperRegistry()
+        reg.register("concept_involvement", concept_involvement)
+        reg.register("rule_challenge", rule_challenge)
+        reg.register("rule_support", rule_support)
+        reg.register("mistake_chain", mistake_chain)
+        reg.register("resolution_rule", resolution_rule)
+        reg.register("resolution_edges", resolution_edges)
+
+        # Apply YAML config
+        for mapper_name in cfg.get("disabled_mappers", []):
+            reg.disable(mapper_name)
+
+        # Verify disabled mappers are gone
+        enabled = reg.enabled_names()
+        assert "resolution_edges" not in enabled
+        assert "concept_involvement" not in enabled
+
+        # Verify remaining mappers still present
+        assert "rule_challenge" in enabled
+        assert "rule_support" in enabled
+        assert "mistake_chain" in enabled
+        assert "resolution_rule" in enabled
+        assert len(enabled) == 4
+
+    def test_disabled_mappers_not_executed(self):
+        """Disabled mappers should produce no output when run_all is called."""
+        import yaml
+
+        yaml_content = """\
+disabled_mappers:
+  - concept_involvement
+"""
+        cfg = yaml.safe_load(yaml_content) or {}
+
+        reg = EdgeMapperRegistry()
+        reg.register("concept_involvement", concept_involvement)
+        for mapper_name in cfg.get("disabled_mappers", []):
+            reg.disable(mapper_name)
+
+        # Run with a mistake that has related_concepts
+        m = _make_mistake(related_concepts=["schema", "migration"])
+        ctx = _make_ctx(m)
+        out = reg.run_all(ctx)
+
+        # concept_involvement is disabled, so no edges
+        assert out.edges == []
+        assert out.rules == []
+
+    def test_empty_disabled_list_keeps_all(self):
+        """An empty disabled_mappers list should keep all mappers enabled."""
+        import yaml
+
+        yaml_content = "disabled_mappers: []\n"
+        cfg = yaml.safe_load(yaml_content) or {}
+
+        reg = EdgeMapperRegistry()
+        reg.register("concept_involvement", concept_involvement)
+        reg.register("rule_challenge", rule_challenge)
+
+        for mapper_name in cfg.get("disabled_mappers", []):
+            reg.disable(mapper_name)
+
+        assert len(reg.enabled_names()) == 2
+
+    def test_unknown_mapper_name_ignored(self):
+        """Disabling a non-existent mapper should not raise."""
+        import yaml
+
+        yaml_content = """\
+disabled_mappers:
+  - nonexistent_mapper
+"""
+        cfg = yaml.safe_load(yaml_content) or {}
+
+        reg = EdgeMapperRegistry()
+        reg.register("concept_involvement", concept_involvement)
+
+        for mapper_name in cfg.get("disabled_mappers", []):
+            reg.disable(mapper_name)
+
+        # nonexistent_mapper is not in the registry, so discard is a no-op
+        assert "concept_involvement" in reg.enabled_names()


### PR DESCRIPTION
## Summary

- **#118**: Fix SQLite backend to persist all 5 enriched Mistake fields + add hypothesis round-trip property test
- **#119**: Replace silent `default=str` in emit_artifact with explicit serializer that raises TypeError for unknown types
- **#120**: Add YAML emissions config integration tests (disabled_mappers, empty list, unknown names)
- **#121**: Document module-level DEFAULT_REGISTRY singleton as intentional (negligible overhead)

## Test plan

- [x] 59 emission tests pass (including 5 new)
- [x] Full suite: 1131 passed, 3 skipped
- [x] Pre-commit hooks pass (black, isort, flake8, mypy)

Closes #118, closes #119, closes #120, closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)