### PR TITLE
feat: file-based gauntlet prompt in compact mode

### DIFF
--- a/src/buildlog/mcp/tools.py
+++ b/src/buildlog/mcp/tools.py
@@ -928,13 +928,16 @@ def buildlog_gauntlet_loop(
         compact: Omit bulky fields that are redundant with the prompt
             (default: True). The prompt already contains all rules, so
             ``rules_by_persona`` is stripped. ``rule_id_index`` is
-            replaced with ``valid_rule_ids`` (just the keys). Set to
-            False to get the full unabridged response.
+            replaced with ``valid_rule_ids`` (just the keys). The full
+            prompt is written to ``.buildlog/gauntlet_prompt.md`` and
+            replaced with a ``prompt_file`` path. Set to False to get
+            the full unabridged response.
 
     Returns:
         Dict with target, personas, max_iterations, stop_at,
-        instructions, issue_format, prompt, valid_rule_ids, message, error.
-        When compact=False, also includes rules_by_persona and rule_id_index.
+        instructions, issue_format, prompt_file, valid_rule_ids, message, error.
+        When compact=False, returns prompt inline instead of prompt_file,
+        and also includes rules_by_persona and rule_id_index.
     """
     result = gauntlet_loop_config(
         target=target,
@@ -954,6 +957,13 @@ def buildlog_gauntlet_loop(
         # param on buildlog_gauntlet_issues), not per-rule metadata.
         rule_id_index = d.pop("rule_id_index", {})
         d["valid_rule_ids"] = sorted(rule_id_index.keys())
+
+        # Write prompt to file instead of returning inline (~22K tokens).
+        prompt_text = d.pop("prompt", "")
+        prompt_path = Path(DEFAULT_BUILDLOG_DIR) / ".buildlog" / "gauntlet_prompt.md"
+        prompt_path.parent.mkdir(parents=True, exist_ok=True)
+        prompt_path.write_text(prompt_text, encoding="utf-8")
+        d["prompt_file"] = str(prompt_path.resolve())
 
     return d
 

--- a/tests/test_p0_gauntlet.py
+++ b/tests/test_p0_gauntlet.py
@@ -257,7 +257,9 @@ class TestBuildlogGauntletLoopMCP:
         assert "stop_at" in result
         assert "instructions" in result
         assert "issue_format" in result
-        assert "prompt" in result
+        # Compact mode (default): prompt written to file, not inline
+        assert "prompt" not in result
+        assert "prompt_file" in result
         # Compact mode (default): rules_by_persona stripped, valid_rule_ids added
         assert "rules_by_persona" not in result
         assert "valid_rule_ids" in result
@@ -288,3 +290,29 @@ class TestBuildlogGauntletLoopMCP:
 
         result = buildlog_gauntlet_loop(target="src/", personas=["bogus"])
         assert result["error"] is not None
+
+    def test_compact_writes_prompt_to_file(self):
+        """Compact mode should write prompt to .buildlog/gauntlet_prompt.md."""
+        from pathlib import Path
+
+        from buildlog.mcp.tools import buildlog_gauntlet_loop
+
+        result = buildlog_gauntlet_loop(target="src/", compact=True)
+        assert "prompt_file" in result
+        assert "prompt" not in result
+
+        prompt_path = Path(result["prompt_file"])
+        assert prompt_path.exists()
+        content = prompt_path.read_text(encoding="utf-8")
+        # Prompt should have real content (not empty) when no error
+        if result.get("error") is None:
+            assert len(content) > 0
+
+    def test_compact_false_returns_prompt_inline(self):
+        """Non-compact mode should return prompt inline, no prompt_file."""
+        from buildlog.mcp.tools import buildlog_gauntlet_loop
+
+        result = buildlog_gauntlet_loop(target="src/", compact=False)
+        assert "prompt" in result
+        assert "prompt_file" not in result
+        assert isinstance(result["prompt"], str)


### PR DESCRIPTION
## Summary
- In compact mode (default), writes the ~22K-token gauntlet prompt to `.buildlog/gauntlet_prompt.md` and returns `prompt_file` path instead of inline `prompt`
- Non-compact mode unchanged — still returns `prompt` inline
- Reduces MCP response payload and calling-agent context consumption

## Test plan
- [x] New test: compact mode returns `prompt_file`, file exists with content, no inline `prompt`
- [x] New test: non-compact mode returns inline `prompt`, no `prompt_file`
- [x] Existing test updated: `test_has_expected_keys` now checks for `prompt_file` instead of `prompt`
- [x] Full test suite passes (1177 passed, 3 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)