### PR TITLE
feat: add llms.txt for AI-queryable docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ buildlog/.buildlog/
 buildlog/bandit_state.jsonl
 buildlog/bandit_state.jsonl.migrated
 site/
+
+# Generated docs (rebuilt by MkDocs hook)
+docs/llms-full.txt

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,0 +1,34 @@
+# buildlog
+
+> Engineering notebook that extracts decision patterns from AI-assisted work and uses Thompson Sampling to surface rules that reduce repeated mistakes — then measures whether they did.
+
+buildlog captures structured journal entries from work sessions, distills them into reusable engineering rules, and uses a contextual bandit (Beta-Bernoulli Thompson Sampling) to automatically select which rules to surface per context. The core metric is Repeated Mistake Rate (RMR): the fraction of mistakes that match previous mistakes. The claim is falsifiable — if buildlog doesn't help, the numbers show it.
+
+Works with Claude Code, Cursor, GitHub Copilot, Windsurf, and Continue.dev via 34 MCP tools.
+
+## Getting Started
+
+- [Installation](https://peleke.github.io/buildlog-template/getting-started/installation/): Requirements, install methods (pip/pipx/uv), optional extras, global always-on mode, per-project setup
+- [Quick Start](https://peleke.github.io/buildlog-template/getting-started/quick-start/): Full pipeline walkthrough — capture, extract, promote, measure, learn
+- [Core Concepts](https://peleke.github.io/buildlog-template/getting-started/concepts/): The problem (nobody measures agent learning), the claim (falsifiable hypothesis), the metric (RMR), Thompson Sampling bandit mechanics
+
+## Guides
+
+- [CLI Reference](https://peleke.github.io/buildlog-template/guides/cli-reference/): All commands — init, entries, skills, experiments, gauntlet, storage, MCP registration
+- [MCP Integration](https://peleke.github.io/buildlog-template/guides/mcp-integration/): Global/local setup, all 34 MCP tools, always-on workflow
+- [Storage Architecture](https://peleke.github.io/buildlog-template/guides/storage-architecture/): Global SQLite backend, StorageBackend protocol, backend resolution, migration from legacy JSON/JSONL
+- [Interop & Seed Ingestion](https://peleke.github.io/buildlog-template/guides/interop/): Directory protocol for external producers, seed file format, 7-layer security validation, version-aware bandit decay
+- [Experiments](https://peleke.github.io/buildlog-template/guides/experiments/): Running tracked sessions, RMR measurement, the falsification protocol, bandit integration
+- [Review Gauntlet](https://peleke.github.io/buildlog-template/guides/review-gauntlet/): Reviewer personas (Security Karen, Test Terrorist, Bragi), gauntlet loop with HITL checkpoints
+- [Multi-Agent Setup](https://peleke.github.io/buildlog-template/guides/multi-agent/): Rendering rules to Claude Code, Cursor, Copilot, Windsurf, Continue.dev
+
+## Optional
+
+- [Theory: The Restaurant Problem](https://peleke.github.io/buildlog-template/theory/intuition/): Exploration vs exploitation through restaurant analogy
+- [Theory: The Price of Learning](https://peleke.github.io/buildlog-template/theory/regret/): Regret bounds and why sublinear regret matters
+- [Theory: Keeping Score](https://peleke.github.io/buildlog-template/theory/beta-distributions/): Beta distributions for representing uncertainty with binary feedback
+- [Theory: Making Decisions](https://peleke.github.io/buildlog-template/theory/thompson-sampling/): Thompson Sampling algorithm — sample, select, observe, update
+- [Theory: Context Changes Everything](https://peleke.github.io/buildlog-template/theory/contextual-bandits/): Per-context posteriors and why the best rule depends on the situation
+- [Philosophy](https://peleke.github.io/buildlog-template/philosophy/): Falsifiability over impressiveness, honest limitations, hard open problems
+- [Roadmap](https://peleke.github.io/buildlog-template/roadmap/): Embedding persistence, cross-project convergence, emergent rule graphs
+- [Contributing](https://peleke.github.io/buildlog-template/development/contributing/): Setup, areas of interest (credit assignment, context representations, statistical methodology)

--- a/hooks/generate_llms_full.py
+++ b/hooks/generate_llms_full.py
@@ -1,0 +1,138 @@
+"""MkDocs hook: generate llms-full.txt from llms.txt + source markdown.
+
+Runs on_pre_build so the generated file is available for MkDocs to copy
+to the site output directory.
+
+The hook parses docs/llms.txt, extracts markdown links, resolves them to
+local source files in docs/, and concatenates everything into docs/llms-full.txt.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from urllib.parse import urlparse
+
+SITE_URL = "https://peleke.github.io/buildlog-template/"
+DOCS_DIR = Path(__file__).resolve().parent.parent / "docs"
+LLMS_TXT = DOCS_DIR / "llms.txt"
+LLMS_FULL_TXT = DOCS_DIR / "llms-full.txt"
+
+
+def _url_to_local_path(url: str) -> Path | None:
+    """Convert a site URL to a local docs/ markdown file path."""
+    parsed = urlparse(url)
+    path = parsed.path
+
+    # Strip the site prefix
+    prefix = "/buildlog-template/"
+    if not path.startswith(prefix):
+        return None
+    relative = path[len(prefix) :]
+
+    # Trailing slash -> index.md inside that directory
+    if relative.endswith("/"):
+        relative += "index.md"
+    elif not relative.endswith(".md"):
+        relative += ".md"
+
+    # MkDocs URL convention: getting-started/installation/ -> getting-started/installation.md
+    # But also could be getting-started/installation/index.md — try both
+    candidate = DOCS_DIR / relative
+    if candidate.exists():
+        return candidate
+
+    # Try without the trailing directory (installation/ -> installation.md)
+    if relative.endswith("/index.md"):
+        alt = DOCS_DIR / relative.replace("/index.md", ".md")
+        if alt.exists():
+            return alt
+
+    return None
+
+
+def _parse_llms_txt(content: str) -> tuple[list[str], list[tuple[str, str, str]]]:
+    """Parse llms.txt into preamble lines and (section, name, url) entries.
+
+    Returns:
+        preamble: Lines before the first link entry (H1, blockquote, paragraphs).
+        entries: List of (section_heading, link_name, url) tuples.
+    """
+    preamble: list[str] = []
+    entries: list[tuple[str, str, str]] = []
+    current_section = ""
+    in_preamble = True
+
+    for line in content.splitlines():
+        # Track H2 sections
+        h2_match = re.match(r"^## (.+)$", line)
+        if h2_match:
+            current_section = h2_match.group(1)
+            in_preamble = False
+            continue
+
+        # Match link entries: - [Name](URL): Description
+        link_match = re.match(r"^- \[(.+?)\]\((.+?)\)", line)
+        if link_match:
+            name = link_match.group(1)
+            url = link_match.group(2)
+            entries.append((current_section, name, url))
+            in_preamble = False
+            continue
+
+        if in_preamble:
+            preamble.append(line)
+
+    return preamble, entries
+
+
+def generate_llms_full() -> str:
+    """Generate llms-full.txt content from llms.txt + source markdown."""
+    llms_content = LLMS_TXT.read_text()
+    preamble, entries = _parse_llms_txt(llms_content)
+
+    parts: list[str] = []
+
+    # Include preamble (H1, blockquote, overview paragraphs)
+    parts.append("\n".join(preamble).strip())
+    parts.append("")
+
+    current_section = ""
+    for section, name, url in entries:
+        # Emit section header on change
+        if section != current_section:
+            current_section = section
+            parts.append(f"\n## {section}\n")
+
+        local_path = _url_to_local_path(url)
+        if local_path and local_path.exists():
+            md_content = local_path.read_text().strip()
+            parts.append(md_content)
+            parts.append("")  # blank line between entries
+        else:
+            # Fallback: keep the link reference
+            parts.append(f"### {name}\n\nSee: {url}\n")
+
+    return "\n".join(parts)
+
+
+# --- MkDocs hook entry point ---
+
+
+def on_pre_build(**kwargs) -> None:  # noqa: ARG001
+    """Generate llms-full.txt before MkDocs builds the site."""
+    if not LLMS_TXT.exists():
+        return
+    content = generate_llms_full()
+    LLMS_FULL_TXT.write_text(content)
+
+
+# --- CLI entry point for manual generation ---
+
+if __name__ == "__main__":
+    if not LLMS_TXT.exists():
+        print(f"Error: {LLMS_TXT} not found")
+        raise SystemExit(1)
+    content = generate_llms_full()
+    LLMS_FULL_TXT.write_text(content)
+    print(f"Generated {LLMS_FULL_TXT} ({len(content)} bytes)")

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,6 +7,9 @@ repo_name: Peleke/buildlog-template
 theme:
   name: readthedocs
 
+hooks:
+  - hooks/generate_llms_full.py
+
 markdown_extensions:
   - admonition
   - attr_list


### PR DESCRIPTION
## Summary

- Adds `llms.txt` (curated index) and `llms-full.txt` (all 18 doc pages inlined, 68KB) to the documentation site
- MkDocs build hook auto-regenerates `llms-full.txt` from source markdown on every build
- Follows the [llms.txt standard](https://llmstxt.org/) so Context7, mcpdoc, and other AI tools can query buildlog docs

## What's included

- `docs/llms.txt` — Curated index with Getting Started, Guides, and Optional (Theory/Philosophy/Roadmap) sections
- `hooks/generate_llms_full.py` — MkDocs `on_pre_build` hook that parses `llms.txt`, resolves URLs to local markdown, inlines everything
- `mkdocs.yml` — Hook registration
- `.gitignore` — Excludes generated `llms-full.txt`

## How it works

The hook runs before every MkDocs build:
1. Parses `docs/llms.txt` for markdown links
2. Resolves each URL to a local `docs/*.md` file
3. Concatenates all content into `docs/llms-full.txt`
4. MkDocs copies both files to the site root

After deploy, these will be available at:
- `peleke.github.io/buildlog-template/llms.txt`
- `peleke.github.io/buildlog-template/llms-full.txt`

## Phase 0 of docs-as-MCP

This is the foundation for Peleke/qortex#46 (serve docs as MCP server). The llms.txt standard is what Context7, mcpdoc, and future qortex docs MCP can all consume. Proves the pattern for the remaining 5 doc sites (qortex, openclaw, cadence, openclaw-sandbox, interoception).

Closes #140

## Test plan

- [x] `python hooks/generate_llms_full.py` generates 68KB file with all 18 pages
- [x] `mkdocs build --strict` passes with hook registered
- [x] Both files present in `site/` output
- [ ] Verify URLs resolve after GitHub Pages deploy
- [ ] Test with `claude mcp add` via mcpdoc pointing at the llms.txt URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)