### PR TITLE
feat: message fields on all MCP responses + bandit health

### DIFF
--- a/src/buildlog/core/operations.py
+++ b/src/buildlog/core/operations.py
@@ -116,6 +116,9 @@ class StatusResult:
     promotable_ids: list[str]
     """IDs of high-confidence skills ready for promotion."""
 
+    message: str = ""
+    """Human-readable summary."""
+
     error: str | None = None
     """Error message if operation failed."""
 
@@ -153,6 +156,9 @@ class RejectResult:
     total_rejected: int
     """Total number of rejected skills."""
 
+    message: str = ""
+    """Human-readable summary."""
+
     error: str | None = None
     """Error message if operation failed."""
 
@@ -172,6 +178,9 @@ class DiffResult:
 
     already_rejected: int
     """Number of previously rejected skills."""
+
+    message: str = ""
+    """Human-readable summary."""
 
     error: str | None = None
     """Error message if operation failed."""
@@ -591,12 +600,16 @@ def status(
     # Calculate actual total (sum of by_confidence, which excludes rejected)
     actual_total = sum(by_confidence.values())
 
+    parts = [f"{actual_total} skills from {skill_set.source_entries} entries"]
+    if promotable:
+        parts.append(f"{len(promotable)} ready to promote")
     return StatusResult(
         skills=filtered,
         total_entries=skill_set.source_entries,
         total_skills=actual_total,
         by_confidence=by_confidence,
         promotable_ids=promotable,
+        message=" | ".join(parts),
     )
 
 
@@ -688,6 +701,7 @@ def reject(
         return RejectResult(
             rejected_ids=[],
             total_rejected=0,
+            message="No skill IDs provided",
             error="No skill IDs provided",
         )
 
@@ -713,6 +727,7 @@ def reject(
     return RejectResult(
         rejected_ids=newly_rejected,
         total_rejected=len(existing_ids),
+        message=f"Rejected {len(newly_rejected)} skill(s), {len(existing_ids)} total rejected",
     )
 
 
@@ -733,6 +748,7 @@ def diff(
             total_pending=0,
             already_promoted=0,
             already_rejected=0,
+            message="No buildlog directory found",
             error=f"No buildlog directory found at {buildlog_dir}",
         )
 
@@ -762,6 +778,7 @@ def diff(
         total_pending=total_pending,
         already_promoted=len(promoted_ids),
         already_rejected=len(rejected_ids),
+        message=f"{total_pending} pending | {len(promoted_ids)} promoted | {len(rejected_ids)} rejected",
     )
 
 
@@ -2231,6 +2248,24 @@ def get_bandit_status(
         for rule in rules
     )
 
+    # Health: count arms with narrow confidence intervals (converging)
+    converging = 0
+    ci_threshold = 0.2  # CI width below which an arm is "converging"
+    for rules in contexts.values():
+        for rule in rules:
+            ci = rule.get("confidence_interval")
+            if ci and (ci[1] - ci[0]) < ci_threshold:
+                converging += 1
+
+    # Human-readable health summary
+    if total_observations == 0:
+        health = "no observations yet"
+    else:
+        parts = [f"{total_observations} obs across {total_arms} arms"]
+        if converging:
+            parts.append(f"{converging} converging")
+        health = " | ".join(parts)
+
     return {
         "summary": {
             "total_contexts": len(contexts),
@@ -2238,6 +2273,7 @@ def get_bandit_status(
             "total_observations": total_observations,
             "backend": bandit.backend_name,
         },
+        "message": health,
         "top_rules": top_rules,
         "all_rules": contexts if context else None,  # Only include all if filtering
     }
@@ -2577,6 +2613,7 @@ class GauntletRulesResult:
     format: str
     total_rules: int
     personas: list[str]
+    message: str = ""
     error: str | None = None
 
 
@@ -2590,6 +2627,7 @@ class OverviewResult:
     render_targets: list[str]
     workflow_ok: bool = True
     workflow_issues: list[str] | None = None
+    message: str = ""
 
 
 @dataclass
@@ -2635,6 +2673,7 @@ def get_gauntlet_rules(
             format=format,
             total_rules=0,
             personas=[],
+            message="No seed files found",
             error="No seed files found. Check your buildlog installation.",
         )
 
@@ -2645,6 +2684,7 @@ def get_gauntlet_rules(
             format=format,
             total_rules=0,
             personas=[],
+            message="No seed files found",
             error="No seed files found in seeds directory.",
         )
 
@@ -2657,6 +2697,7 @@ def get_gauntlet_rules(
                 format=format,
                 total_rules=0,
                 personas=[],
+                message=f"Unknown persona: {persona}",
                 error=f"Unknown persona: {persona}. Available: {available}",
             )
         seeds = {persona: seeds[persona]}
@@ -2712,6 +2753,7 @@ def get_gauntlet_rules(
         format=format,
         total_rules=total_rules,
         personas=list(seeds.keys()),
+        message=f"{total_rules} rules across {len(seeds)} persona(s)",
     )
 
 
@@ -2792,6 +2834,8 @@ def get_overview(
     if active_data is not None:
         active_session = active_data.get("id")
 
+    pending_count = total_skills - promoted_count - rejected_count
+    session_note = f" | session: {active_session}" if active_session else ""
     return OverviewResult(
         entries=len(entries),
         skills={
@@ -2799,10 +2843,11 @@ def get_overview(
             "by_confidence": by_confidence,
             "promoted": promoted_count,
             "rejected": rejected_count,
-            "pending": total_skills - promoted_count - rejected_count,
+            "pending": pending_count,
         },
         active_session=active_session,
         render_targets=list(RENDERERS.keys()),
+        message=f"{len(entries)} entries, {total_skills} skills ({pending_count} pending){session_note}",
         **_quick_workflow_check(buildlog_dir),
     )
 
@@ -3597,6 +3642,7 @@ class VerifyResult:
     failed: list[VerifyCheck]
     ok: bool
     summary: str
+    message: str = ""
 
 
 def gauntlet_generate(
@@ -4181,4 +4227,5 @@ def verify_workflow(
         failed=failed,
         ok=ok,
         summary=summary,
+        message=summary,
     )

--- a/src/buildlog/mcp/tools.py
+++ b/src/buildlog/mcp/tools.py
@@ -38,6 +38,16 @@ from buildlog.core import (
 )
 
 
+def _ensure_message(d: dict) -> dict:
+    """Ensure the result dict has a non-empty ``message`` for MCP display.
+
+    Falls back to ``error`` when ``message`` is empty/missing.
+    """
+    if not d.get("message") and d.get("error"):
+        d["message"] = d["error"]
+    return d
+
+
 def _project_root(buildlog_dir: str) -> Path:
     """Derive the project root from the buildlog directory path.
 
@@ -135,7 +145,7 @@ def buildlog_status(
         Dictionary with skills by category and summary statistics
     """
     result = status(Path(buildlog_dir), min_confidence)
-    return asdict(result)
+    return _ensure_message(asdict(result))
 
 
 def buildlog_promote(
@@ -158,7 +168,7 @@ def buildlog_promote(
     """
     validated_ids = _validate_skill_ids(skill_ids)
     result = promote(Path(buildlog_dir), validated_ids, target)
-    return asdict(result)
+    return _ensure_message(asdict(result))
 
 
 def buildlog_reject(
@@ -178,7 +188,7 @@ def buildlog_reject(
     """
     validated_ids = _validate_skill_ids(skill_ids)
     result = reject(Path(buildlog_dir), validated_ids)
-    return asdict(result)
+    return _ensure_message(asdict(result))
 
 
 def buildlog_diff(
@@ -195,7 +205,7 @@ def buildlog_diff(
         Dictionary with pending skills and counts
     """
     result = diff(Path(buildlog_dir))
-    return asdict(result)
+    return _ensure_message(asdict(result))
 
 
 def buildlog_learn_from_review(
@@ -259,7 +269,7 @@ def buildlog_learn_from_review(
         }
 
     result = learn_from_review(Path(buildlog_dir), resolved, source)
-    return asdict(result)
+    return _ensure_message(asdict(result))
 
 
 def buildlog_log_reward(
@@ -327,7 +337,7 @@ def buildlog_log_reward(
         source="mcp",
         session_id=session_id,
     )
-    return asdict(result)
+    return _ensure_message(asdict(result))
 
 
 def buildlog_rewards(
@@ -413,7 +423,7 @@ def buildlog_experiment_start(
         notes=notes,
         select_k=select_k,
     )
-    return asdict(result)
+    return _ensure_message(asdict(result))
 
 
 def buildlog_experiment_end(
@@ -445,7 +455,7 @@ def buildlog_experiment_end(
         entry_file=entry_file,
         notes=notes,
     )
-    return asdict(result)
+    return _ensure_message(asdict(result))
 
 
 def buildlog_log_mistake(
@@ -501,7 +511,7 @@ def buildlog_log_mistake(
         context=context,
         severity=severity,
     )
-    return asdict(result)
+    return _ensure_message(asdict(result))
 
 
 def buildlog_experiment_metrics(
@@ -528,7 +538,7 @@ def buildlog_experiment_metrics(
         Path(buildlog_dir),
         session_id=session_id,
     )
-    return asdict(result)
+    return _ensure_message(asdict(result))
 
 
 def buildlog_experiment_report(
@@ -684,7 +694,7 @@ def buildlog_gauntlet_issues(
         source=source,
         valid_rule_ids=set(valid_rule_ids) if valid_rule_ids else None,
     )
-    return asdict(result)
+    return _ensure_message(asdict(result))
 
 
 def buildlog_gauntlet_accept_risk(
@@ -746,7 +756,7 @@ def buildlog_gauntlet_accept_risk(
         repo=repo,
         cwd=str(_project_root(buildlog_dir)) if buildlog_dir else None,
     )
-    return asdict(result)
+    return _ensure_message(asdict(result))
 
 
 # -----------------------------------------------------------------------------
@@ -773,7 +783,7 @@ def buildlog_gauntlet_rules(
         Dict with formatted rules, total_rules, personas list
     """
     result = get_gauntlet_rules(persona=persona, format=format)
-    return asdict(result)
+    return _ensure_message(asdict(result))
 
 
 def buildlog_overview(
@@ -790,7 +800,7 @@ def buildlog_overview(
         Dict with entries, skills, active_session, render_targets
     """
     result = get_overview(Path(buildlog_dir))
-    return asdict(result)
+    return _ensure_message(asdict(result))
 
 
 def buildlog_entry_new(
@@ -822,7 +832,7 @@ def buildlog_entry_new(
         entry_date=entry_date,
         quick=quick,
     )
-    return asdict(result)
+    return _ensure_message(asdict(result))
 
 
 def buildlog_entry_list(
@@ -839,7 +849,7 @@ def buildlog_entry_list(
         Dict with entries list [{name, title}], count, message
     """
     result = list_entries(Path(buildlog_dir))
-    return asdict(result)
+    return _ensure_message(asdict(result))
 
 
 # =============================================================================
@@ -881,7 +891,7 @@ def buildlog_commit(
         no_entry=no_entry,
         cwd=str(_project_root(buildlog_dir)),
     )
-    return asdict(result)
+    return _ensure_message(asdict(result))
 
 
 def buildlog_gauntlet_prompt(
@@ -911,7 +921,7 @@ def buildlog_gauntlet_prompt(
         buildlog_dir=Path(buildlog_dir) if select_k is not None else None,
         select_k=select_k,
     )
-    return asdict(result)
+    return _ensure_message(asdict(result))
 
 
 def buildlog_gauntlet_loop(
@@ -970,7 +980,7 @@ def buildlog_gauntlet_loop(
         rule_id_index = d.pop("rule_id_index", {})
         d["valid_rule_ids"] = sorted(rule_id_index.keys())
 
-    return d
+    return _ensure_message(d)
 
 
 # =============================================================================
@@ -1261,7 +1271,7 @@ def buildlog_gauntlet_generate(
         output_dir=out,
         dry_run=dry_run,
     )
-    return asdict(result)
+    return _ensure_message(asdict(result))
 
 
 def buildlog_migrate(
@@ -1344,7 +1354,7 @@ def buildlog_import_seed(
             target_dir=resolved_target,
             buildlog_dir=Path(buildlog_dir),
         )
-        return asdict(result)
+        return _ensure_message(asdict(result))
     except (FileNotFoundError, ValueError) as e:
         return {
             "persona": "",
@@ -1486,7 +1496,7 @@ def buildlog_init(
         no_claude_md=no_claude_md,
         no_mcp=no_mcp,
     )
-    return asdict(result)
+    return _ensure_message(asdict(result))
 
 
 def buildlog_update(
@@ -1504,7 +1514,7 @@ def buildlog_update(
         Dict with updated, message, error
     """
     result = update_buildlog(project_dir=Path(project_dir).resolve())
-    return asdict(result)
+    return _ensure_message(asdict(result))
 
 
 def buildlog_verify(
@@ -1531,4 +1541,4 @@ def buildlog_verify(
         project_dir=project_dir,
         buildlog_dir=Path(buildlog_dir).resolve(),
     )
-    return asdict(result)
+    return _ensure_message(asdict(result))


### PR DESCRIPTION
## Summary
- Every `Result` dataclass now declares a `message: str = ""` field populated with a human-readable one-liner
- MCP layer wraps all `asdict(result)` calls with `_ensure_message()` — falls back to `error` when `message` is empty
- `get_bandit_status()` now includes a `message` key with health summary (e.g. "22 obs across 36 arms | 3 converging")

## Test plan
- [x] 1239 tests pass, 0 failures
- [x] Manual verify: `get_bandit_status()` returns health string
- [x] Pre-commit (black, isort, flake8, mypy) all pass


🤖 Generated with [Claude Code](https://claude.com/claude-code)