### PR TITLE
fix: gauntlet followup — tests, defensive CI, no-mutation, rewards gap

### DIFF
--- a/src/buildlog/core/operations.py
+++ b/src/buildlog/core/operations.py
@@ -85,6 +85,12 @@ __all__ = [
 ]
 
 
+# CI width below which a bandit arm is considered "converging".
+# With Beta(a, b), 95% CI width ≈ 3.92 * sqrt(ab / ((a+b)^2 * (a+b+1))).
+# 0.2 corresponds to roughly 25+ observations with moderate success rate.
+_CONVERGENCE_CI_WIDTH = 0.2
+
+
 def _get_storage(buildlog_dir: Path) -> tuple[StorageBackend, str]:
     """Resolve the storage backend for the project containing *buildlog_dir*.
 
@@ -2250,11 +2256,14 @@ def get_bandit_status(
 
     # Health: count arms with narrow confidence intervals (converging)
     converging = 0
-    ci_threshold = 0.2  # CI width below which an arm is "converging"
-    for rules in contexts.values():
-        for rule in rules:
-            ci = rule.get("confidence_interval")
-            if ci and (ci[1] - ci[0]) < ci_threshold:
+    for ctx_rules in contexts.values():
+        for arm in ctx_rules:
+            ci = arm.get("confidence_interval")
+            if (
+                isinstance(ci, (list, tuple))
+                and len(ci) >= 2
+                and (ci[1] - ci[0]) < _CONVERGENCE_CI_WIDTH
+            ):
                 converging += 1
 
     # Human-readable health summary
@@ -2648,7 +2657,7 @@ class ListEntriesResult:
 
     entries: list[dict]
     count: int
-    message: str | None = None
+    message: str = ""
 
 
 def get_gauntlet_rules(
@@ -3026,9 +3035,11 @@ def list_entries(
             title = "(unreadable)"
         entries.append({"name": ep.name, "title": title})
 
-    message = None
+    message = ""
     if not entries:
         message = "No entries yet. Create one with: buildlog new my-feature"
+    else:
+        message = f"{len(entries)} entries"
 
     return ListEntriesResult(
         entries=entries,

--- a/src/buildlog/mcp/tools.py
+++ b/src/buildlog/mcp/tools.py
@@ -39,12 +39,16 @@ from buildlog.core import (
 
 
 def _ensure_message(d: dict) -> dict:
-    """Ensure the result dict has a non-empty ``message`` for MCP display.
+    """Return a copy of *d* with a non-empty ``message`` for MCP display.
 
     Falls back to ``error`` when ``message`` is empty/missing.
+    The error string is used as-is since MCP consumers are local agents
+    (not end-user UIs), so path information is acceptable.
     """
     if not d.get("message") and d.get("error"):
-        d["message"] = d["error"]
+        out = dict(d)
+        out["message"] = out["error"]
+        return out
     return d
 
 
@@ -371,14 +375,17 @@ def buildlog_rewards(
     result = get_rewards(Path(buildlog_dir), limit, session_id=session_id)
 
     # Convert events to dicts
-    return {
-        "total_events": result.total_events,
-        "accepted": result.accepted,
-        "revisions": result.revisions,
-        "rejected": result.rejected,
-        "mean_reward": result.mean_reward,
-        "events": [e.to_dict() for e in result.events],
-    }
+    return _ensure_message(
+        {
+            "total_events": result.total_events,
+            "accepted": result.accepted,
+            "revisions": result.revisions,
+            "rejected": result.rejected,
+            "mean_reward": result.mean_reward,
+            "events": [e.to_dict() for e in result.events],
+            "message": f"{result.total_events} events (mean reward: {result.mean_reward:.2f})",
+        }
+    )
 
 
 # -----------------------------------------------------------------------------

--- a/tests/test_bandit.py
+++ b/tests/test_bandit.py
@@ -1057,6 +1057,129 @@ class TestBanditWithSqlitePersistence:
         bandit2 = ThompsonSamplingBandit(SqlitePersistence(backend, project_id))
         assert bandit2.state.get_params("ctx", "r1") is None
 
+
+# ---------------------------------------------------------------------------
+# get_bandit_status health summary tests
+# ---------------------------------------------------------------------------
+
+
+class TestBanditStatusHealth:
+    """Tests for the health summary in get_bandit_status()."""
+
+    def test_no_observations_message(self, tmp_path):
+        """Empty bandit → 'no observations yet'."""
+        from buildlog.core.operations import get_bandit_status
+
+        bd = tmp_path / "buildlog" / ".buildlog"
+        bd.mkdir(parents=True)
+        result = get_bandit_status(bd)
+        assert result["message"] == "no observations yet"
+        assert result["summary"]["total_observations"] == 0
+
+    def test_observations_without_converging(self, tmp_path):
+        """Arms with wide CIs → obs count but no converging."""
+        from unittest.mock import patch
+
+        from buildlog.core.bandit import JsonlPersistence, ThompsonSamplingBandit
+        from buildlog.core.learning import BuiltinBandit
+        from buildlog.core.operations import get_bandit_status
+
+        bd = tmp_path / "buildlog" / ".buildlog"
+        bd.mkdir(parents=True)
+        p = JsonlPersistence(bd / "bandit_state.jsonl")
+        bandit = ThompsonSamplingBandit(p)
+        bandit.select(candidates=["r1", "r2"], context="ctx", k=2)
+        bandit.update("r1", 1.0, "ctx")
+        bandit.update("r2", 0.0, "ctx")
+
+        with patch(
+            "buildlog.core.operations.get_learning_backend",
+            return_value=BuiltinBandit(bandit),
+        ):
+            result = get_bandit_status(bd)
+        assert "obs across" in result["message"]
+        assert "converging" not in result["message"]
+
+    def test_converging_arm_detected(self, tmp_path):
+        """Arms with many observations develop narrow CIs → converging count."""
+        from unittest.mock import patch
+
+        from buildlog.core.bandit import JsonlPersistence, ThompsonSamplingBandit
+        from buildlog.core.learning import BuiltinBandit
+        from buildlog.core.operations import get_bandit_status
+
+        bd = tmp_path / "buildlog" / ".buildlog"
+        bd.mkdir(parents=True)
+        p = JsonlPersistence(bd / "bandit_state.jsonl")
+        bandit = ThompsonSamplingBandit(p)
+        bandit.select(candidates=["r1"], context="ctx", k=1)
+        for _ in range(50):
+            bandit.update("r1", 1.0, "ctx")
+
+        with patch(
+            "buildlog.core.operations.get_learning_backend",
+            return_value=BuiltinBandit(bandit),
+        ):
+            result = get_bandit_status(bd)
+        assert "converging" in result["message"]
+
+    def test_malformed_ci_does_not_crash(self, tmp_path):
+        """Arms with missing/malformed confidence_interval → no crash."""
+        from unittest.mock import patch
+
+        from buildlog.core.operations import get_bandit_status
+
+        bd = tmp_path / "buildlog" / ".buildlog"
+        bd.mkdir(parents=True)
+
+        # Mock get_learning_backend to return stats with bad CI data
+        class FakeBackend:
+            backend_name = "test"
+
+            def get_stats(self, context=None):
+                return {
+                    "r1": {
+                        "context": "ctx",
+                        "mean": 0.5,
+                        "confidence_interval": None,
+                        "total_observations": 5,
+                    },
+                    "r2": {
+                        "context": "ctx",
+                        "mean": 0.7,
+                        "confidence_interval": (0.6,),  # too short
+                        "total_observations": 3,
+                    },
+                    "r3": {
+                        "context": "ctx",
+                        "mean": 0.8,
+                        "confidence_interval": "bad",  # wrong type
+                        "total_observations": 2,
+                    },
+                }
+
+            def get_top_rules(self, context, k=10):
+                return []
+
+        with patch(
+            "buildlog.core.operations.get_learning_backend",
+            return_value=FakeBackend(),
+        ):
+            result = get_bandit_status(bd)
+        # Should not crash, and should count 0 converging
+        assert "obs across" in result["message"]
+        assert "converging" not in result["message"]
+
+    def test_health_message_key_always_present(self, tmp_path):
+        """Result dict always has 'message' key."""
+        from buildlog.core.operations import get_bandit_status
+
+        bd = tmp_path / "buildlog" / ".buildlog"
+        bd.mkdir(parents=True)
+        result = get_bandit_status(bd)
+        assert "message" in result
+        assert isinstance(result["message"], str)
+
     def test_decay_persists_via_sqlite(self, sqlite_backend):
         backend, project_id = sqlite_backend
         persistence = SqlitePersistence(backend, project_id)

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -10,6 +10,7 @@ import pytest
 import yaml
 
 from buildlog.mcp.tools import (
+    _ensure_message,
     _resolve_file_or_inline,
     _resolve_text_file_or_inline,
     buildlog_diff,
@@ -768,3 +769,73 @@ class TestBuildlogImportSeed:
 
         assert result["error"] is not None
         assert "within working directory" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# _ensure_message tests
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureMessage:
+    """Tests for _ensure_message() MCP helper."""
+
+    def test_message_present_unchanged(self):
+        """When message is already set, return as-is."""
+        d = {"message": "hello", "error": None}
+        result = _ensure_message(d)
+        assert result["message"] == "hello"
+
+    def test_empty_message_falls_back_to_error(self):
+        """Empty message + error present → message = error."""
+        d = {"message": "", "error": "something broke"}
+        result = _ensure_message(d)
+        assert result["message"] == "something broke"
+
+    def test_missing_message_falls_back_to_error(self):
+        """No message key + error present → message = error."""
+        d = {"error": "not found"}
+        result = _ensure_message(d)
+        assert result["message"] == "not found"
+
+    def test_none_message_falls_back_to_error(self):
+        """message=None + error present → message = error."""
+        d = {"message": None, "error": "null case"}
+        result = _ensure_message(d)
+        assert result["message"] == "null case"
+
+    def test_both_empty_no_crash(self):
+        """Both message and error empty → no change."""
+        d = {"message": "", "error": ""}
+        result = _ensure_message(d)
+        assert result["message"] == ""
+
+    def test_neither_present_no_crash(self):
+        """No message, no error → no crash, no message added."""
+        d = {"data": 42}
+        result = _ensure_message(d)
+        assert "message" not in result
+
+    def test_does_not_mutate_input(self):
+        """Must not mutate the input dict when fallback is applied."""
+        d = {"message": "", "error": "fallback"}
+        result = _ensure_message(d)
+        assert result["message"] == "fallback"
+        assert d["message"] == ""  # original unchanged
+
+    def test_no_copy_when_message_present(self):
+        """When no fallback needed, may return same object (no copy needed)."""
+        d = {"message": "ok", "error": None}
+        result = _ensure_message(d)
+        assert result is d  # no copy overhead
+
+    def test_mcp_tools_have_message_in_response(self):
+        """Status tool (representative) should include message in output."""
+        result = buildlog_status(buildlog_dir=str(FIXTURES_DIR))
+        assert "message" in result
+        assert isinstance(result["message"], str)
+
+    def test_error_path_has_message_via_fallback(self, tmp_path):
+        """Error path should get message populated via _ensure_message."""
+        result = buildlog_status(buildlog_dir=str(tmp_path / "nope"))
+        assert result["error"] is not None
+        assert result["message"]  # non-empty


### PR DESCRIPTION
## Summary
Fixes 8 issues from gauntlet review of PR #159:

- **10 new tests** for `_ensure_message()` covering all edge cases (empty, None, missing, no-mutation)
- **5 new tests** for bandit health summary (no-obs, wide CI, converging, malformed CI, key presence)
- `confidence_interval` shape validated before arithmetic (prevents IndexError on malformed data)
- `_ensure_message()` returns copy instead of mutating input dict (command/query separation)
- `ListEntriesResult.message` normalized from `str | None` to `str = ""`
- `buildlog_rewards()` now uses `_ensure_message()` + populates `message` field
- `ci_threshold` extracted to `_CONVERGENCE_CI_WIDTH` module constant with documented rationale

1254 tests pass (15 new).

## Test plan
- [x] 10 `_ensure_message` tests pass (mutation, fallback, edge cases)
- [x] 5 bandit health tests pass (all 3 branches + malformed CI + key presence)
- [x] Full suite: 1254 passed, 0 failures
- [x] Pre-commit (black, isort, flake8, mypy) all pass


🤖 Generated with [Claude Code](https://claude.com/claude-code)