### PR TITLE
feat: unify skills and gauntlet rules — close the learning loop

### DIFF
--- a/src/buildlog/core/operations.py
+++ b/src/buildlog/core/operations.py
@@ -684,6 +684,55 @@ def promote(
     metadata = {s.id: now for s in found_skills}
     backend.save_id_set(project_id, "promoted", new_ids, metadata)  # type: ignore[arg-type]
 
+    # =========================================================================
+    # UNIFICATION: Insert promoted skills into gauntlet_rules table.
+    #
+    # Skills and gauntlet rules are the same concept — actionable rules that
+    # get selected by the bandit and reviewed by the gauntlet. Without this,
+    # promoted skills feed the bandit but never enter the gauntlet review loop.
+    # =========================================================================
+    try:
+        gauntlet_rows = []
+        for s in found_skills:
+            provenance = json.dumps(
+                {
+                    "source": "skill_promotion",
+                    "skill_id": s.id,
+                    "category": s.category,
+                    "confidence": getattr(s, "confidence_score", None),
+                    "confidence_tier": getattr(s, "confidence_tier", None),
+                    "frequency": s.frequency,
+                    "sources": s.sources[:5] if s.sources else [],
+                    "derivation": "learned",
+                }
+            )
+            gauntlet_rows.append(
+                {
+                    "rule_id": s.id,
+                    "persona": "learned",
+                    "rule": s.rule,
+                    "category": s.category,
+                    "context": getattr(s, "context", "") or "",
+                    "antipattern": getattr(s, "antipattern", "") or "",
+                    "rationale": getattr(s, "rationale", "") or "",
+                    "tags": json.dumps(s.tags if s.tags else []),
+                    "refs": "[]",
+                    "provenance": provenance,
+                    "version": 1,
+                    "active": 1,
+                }
+            )
+        if gauntlet_rows:
+            backend.save_gauntlet_rules_batch(
+                gauntlet_rows,
+                seed_file_hash=None,
+                seed_filename="skill_promotion",
+            )
+    except Exception:
+        logging.getLogger(__name__).debug(
+            "Failed to insert promoted skills into gauntlet_rules", exc_info=True
+        )
+
     return PromoteResult(
         promoted_ids=[s.id for s in found_skills],
         target=target,
@@ -1791,9 +1840,27 @@ def _compute_semantic_hash(description: str) -> str:
 
 
 def _get_current_rules(buildlog_dir: Path) -> list[str]:
-    """Get list of current promoted rule IDs."""
+    """Get list of current rule IDs — promoted skills + active gauntlet rules.
+
+    Returns the UNIFIED pool of rules for bandit selection:
+    - Promoted skill IDs (from skill_decisions)
+    - Active gauntlet rule IDs (from gauntlet_rules WHERE active = 1)
+
+    This ensures the bandit selects from ALL rules, whether they came
+    from journal extraction (skills) or YAML seed import (gauntlet rules).
+    """
     backend, project_id = _get_storage(buildlog_dir)
-    return sorted(backend.load_id_set(project_id, "promoted"))
+    promoted = backend.load_id_set(project_id, "promoted")
+
+    # Also include active gauntlet rules
+    gauntlet_ids: set[str] = set()
+    try:
+        rows = backend.load_gauntlet_rules(active_only=True)
+        gauntlet_ids = {r["rule_id"] for r in rows}
+    except Exception:
+        pass
+
+    return sorted(promoted | gauntlet_ids)
 
 
 def _get_seed_rule_ids(buildlog_dir: Path) -> tuple[set[str], dict[str, float]]:

--- a/tests/test_rule_unification.py
+++ b/tests/test_rule_unification.py
@@ -1,0 +1,283 @@
+"""Tests for rule unification: skills → gauntlet_rules on promote().
+
+Verifies that:
+1. promote() inserts skills into gauntlet_rules table
+2. _get_current_rules() returns both promoted skills AND gauntlet rules
+3. The unified pool is deduplicated and excludes inactive rules
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from buildlog.core.operations import _get_current_rules, promote
+from buildlog.skills import Skill, SkillSet, _generate_skill_id
+from buildlog.storage.schema import init_schema
+from buildlog.storage.sqlite import SQLiteBackend
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _init_backend(tmp_path: Path) -> tuple[SQLiteBackend, str, Path]:
+    """Create a fresh backend with schema."""
+    buildlog_dir = tmp_path / "project"
+    db_dir = buildlog_dir / ".buildlog"
+    db_dir.mkdir(parents=True)
+    db_path = db_dir / "buildlog.db"
+
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    init_schema(conn)
+
+    backend = SQLiteBackend(conn)
+    project_id = "test-project"
+    backend.ensure_project(project_id, "Test Project", str(buildlog_dir))
+
+    return backend, project_id, buildlog_dir
+
+
+def _make_skill(rule: str, category: str = "architectural", **kw) -> Skill:
+    """Create a test Skill."""
+    return Skill(
+        id=_generate_skill_id(category, rule),
+        category=category,
+        rule=rule,
+        frequency=kw.get("frequency", 3),
+        confidence="high",
+        sources=kw.get("sources", ["test.md"]),
+        tags=kw.get("tags", []),
+    )
+
+
+def _insert_gauntlet_rule(
+    backend: SQLiteBackend,
+    rule_id: str,
+    rule: str,
+    persona: str = "test_persona",
+    active: int = 1,
+) -> None:
+    """Insert a gauntlet rule directly."""
+    backend.save_gauntlet_rules_batch(
+        [
+            {
+                "rule_id": rule_id,
+                "persona": persona,
+                "rule": rule,
+                "category": "principle",
+                "context": "",
+                "antipattern": "",
+                "rationale": "",
+                "tags": "[]",
+                "refs": "[]",
+                "provenance": json.dumps({"derivation": "seed"}),
+                "version": 1,
+                "active": active,
+            }
+        ]
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests: promote() inserts into gauntlet_rules
+# ---------------------------------------------------------------------------
+
+
+class TestPromoteInsertsGauntletRules:
+    def test_promoted_skill_appears_in_gauntlet_rules(self, tmp_path: Path):
+        """A promoted skill should be inserted into gauntlet_rules."""
+        backend, project_id, buildlog_dir = _init_backend(tmp_path)
+
+        skill = _make_skill("Always test edge cases", "architectural")
+
+        # Mock generate_skills to return our skill
+        skill_set = SkillSet(
+            generated_at=datetime.now(timezone.utc).isoformat(),
+            source_entries=1,
+            skills={"architectural": [skill]},
+        )
+
+        with (
+            patch("buildlog.core.operations.generate_skills", return_value=skill_set),
+            patch(
+                "buildlog.core.operations._get_storage",
+                return_value=(backend, project_id),
+            ),
+        ):
+            result = promote(
+                buildlog_dir=buildlog_dir,
+                skill_ids=[skill.id],
+                target="skill",
+            )
+
+        assert skill.id in result.promoted_ids
+
+        # Verify it's in gauntlet_rules
+        rows = backend.load_gauntlet_rules(active_only=True)
+        gauntlet_ids = {r["rule_id"] for r in rows}
+        assert skill.id in gauntlet_ids
+
+    def test_gauntlet_rule_has_learned_persona(self, tmp_path: Path):
+        """Skills inserted into gauntlet_rules should have persona='learned'."""
+        backend, project_id, buildlog_dir = _init_backend(tmp_path)
+
+        skill = _make_skill("Use dependency injection", "architectural")
+        skill_set = SkillSet(
+            generated_at=datetime.now(timezone.utc).isoformat(),
+            source_entries=1,
+            skills={"architectural": [skill]},
+        )
+
+        with (
+            patch("buildlog.core.operations.generate_skills", return_value=skill_set),
+            patch(
+                "buildlog.core.operations._get_storage",
+                return_value=(backend, project_id),
+            ),
+        ):
+            promote(buildlog_dir=buildlog_dir, skill_ids=[skill.id], target="skill")
+
+        rows = backend.load_gauntlet_rules(persona="learned")
+        assert len(rows) >= 1
+        rule = next(r for r in rows if r["rule_id"] == skill.id)
+        assert rule["rule"] == "Use dependency injection"
+        assert rule["category"] == "architectural"
+
+    def test_gauntlet_rule_has_provenance(self, tmp_path: Path):
+        """Provenance should record skill_promotion source."""
+        backend, project_id, buildlog_dir = _init_backend(tmp_path)
+
+        skill = _make_skill("Keep functions pure", "workflow")
+        skill_set = SkillSet(
+            generated_at=datetime.now(timezone.utc).isoformat(),
+            source_entries=1,
+            skills={"workflow": [skill]},
+        )
+
+        with (
+            patch("buildlog.core.operations.generate_skills", return_value=skill_set),
+            patch(
+                "buildlog.core.operations._get_storage",
+                return_value=(backend, project_id),
+            ),
+        ):
+            promote(buildlog_dir=buildlog_dir, skill_ids=[skill.id], target="skill")
+
+        rows = backend.load_gauntlet_rules(persona="learned")
+        rule = next(r for r in rows if r["rule_id"] == skill.id)
+        prov = json.loads(rule["provenance"])
+        assert prov["source"] == "skill_promotion"
+        assert prov["skill_id"] == skill.id
+        assert prov["derivation"] == "learned"
+
+    def test_idempotent_promotion(self, tmp_path: Path):
+        """Promoting same skill twice doesn't create duplicates."""
+        backend, project_id, buildlog_dir = _init_backend(tmp_path)
+
+        skill = _make_skill("Test all edge cases", "architectural")
+        skill_set = SkillSet(
+            generated_at=datetime.now(timezone.utc).isoformat(),
+            source_entries=1,
+            skills={"architectural": [skill]},
+        )
+
+        with (
+            patch("buildlog.core.operations.generate_skills", return_value=skill_set),
+            patch(
+                "buildlog.core.operations._get_storage",
+                return_value=(backend, project_id),
+            ),
+        ):
+            promote(buildlog_dir=buildlog_dir, skill_ids=[skill.id], target="skill")
+            promote(buildlog_dir=buildlog_dir, skill_ids=[skill.id], target="skill")
+
+        rows = backend.load_gauntlet_rules(persona="learned")
+        matching = [r for r in rows if r["rule_id"] == skill.id]
+        assert len(matching) == 1  # upsert, not duplicate
+
+
+# ---------------------------------------------------------------------------
+# Tests: _get_current_rules() returns unified pool
+# ---------------------------------------------------------------------------
+
+
+class TestGetCurrentRulesUnified:
+    def test_returns_promoted_skills(self, tmp_path: Path):
+        """Returns promoted skill IDs."""
+        backend, project_id, buildlog_dir = _init_backend(tmp_path)
+
+        backend.save_id_set(project_id, "promoted", {"arch-abc", "dk-xyz"})
+
+        with patch(
+            "buildlog.core.operations._get_storage", return_value=(backend, project_id)
+        ):
+            rules = _get_current_rules(buildlog_dir)
+
+        assert "arch-abc" in rules
+        assert "dk-xyz" in rules
+
+    def test_returns_gauntlet_rules(self, tmp_path: Path):
+        """Returns active gauntlet rule IDs."""
+        backend, project_id, buildlog_dir = _init_backend(tmp_path)
+
+        _insert_gauntlet_rule(backend, "test_terrorist:abc123", "Test everything")
+
+        with patch(
+            "buildlog.core.operations._get_storage", return_value=(backend, project_id)
+        ):
+            rules = _get_current_rules(buildlog_dir)
+
+        assert "test_terrorist:abc123" in rules
+
+    def test_returns_union_of_both(self, tmp_path: Path):
+        """Returns BOTH promoted skills AND gauntlet rules."""
+        backend, project_id, buildlog_dir = _init_backend(tmp_path)
+
+        backend.save_id_set(project_id, "promoted", {"arch-abc"})
+        _insert_gauntlet_rule(backend, "test_terrorist:abc123", "Test everything")
+
+        with patch(
+            "buildlog.core.operations._get_storage", return_value=(backend, project_id)
+        ):
+            rules = _get_current_rules(buildlog_dir)
+
+        assert "arch-abc" in rules
+        assert "test_terrorist:abc123" in rules
+        assert len(rules) >= 2
+
+    def test_deduplication(self, tmp_path: Path):
+        """If a skill ID is in both promoted and gauntlet_rules, no dupes."""
+        backend, project_id, buildlog_dir = _init_backend(tmp_path)
+
+        # Same ID in both places (happens after promote() unification)
+        backend.save_id_set(project_id, "promoted", {"arch-abc"})
+        _insert_gauntlet_rule(backend, "arch-abc", "Some rule")
+
+        with patch(
+            "buildlog.core.operations._get_storage", return_value=(backend, project_id)
+        ):
+            rules = _get_current_rules(buildlog_dir)
+
+        assert rules.count("arch-abc") == 1
+
+    def test_excludes_inactive_gauntlet_rules(self, tmp_path: Path):
+        """Inactive gauntlet rules are NOT in the pool."""
+        backend, project_id, buildlog_dir = _init_backend(tmp_path)
+
+        _insert_gauntlet_rule(backend, "active:rule", "Active rule", active=1)
+        _insert_gauntlet_rule(backend, "inactive:rule", "Inactive rule", active=0)
+
+        with patch(
+            "buildlog.core.operations._get_storage", return_value=(backend, project_id)
+        ):
+            rules = _get_current_rules(buildlog_dir)
+
+        assert "active:rule" in rules
+        assert "inactive:rule" not in rules


### PR DESCRIPTION
## Summary

- `promote()` now inserts promoted skills into the `gauntlet_rules` table with `persona="learned"` and full provenance tracking (source, skill_id, category, confidence, derivation)
- `_get_current_rules()` now returns the **union** of promoted skill IDs and active gauntlet rule IDs, so `start_session()` → `bandit.select()` picks from the full pool
- Idempotent: promoting the same skill twice doesn't create duplicates (upsert via `save_gauntlet_rules_batch`)

**Before**: 10 promoted skills visible to bandit, 102 gauntlet rules invisible. 13 gauntlet-style bandit arms orphaned with learned priors that never got selected.

**After**: All 112+ rules in the selection pool. Skills flow: journal → distill → skills → promote → gauntlet_rules → bandit selection → review loop.

## Test plan

- [x] 9 new tests in `test_rule_unification.py` — all pass
- [x] Full suite: 1,449 passed, 3 skipped, 0 failed
- [ ] Manual: `buildlog_promote()` → verify skill appears in `gauntlet_rules` with `persona="learned"`
- [ ] Manual: `buildlog_status()` → verify `_get_current_rules()` returns 100+ rules (not just 10)

Closes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)