### PR TITLE
fix: dashboard dropdown initial value

### DIFF
--- a/notebooks/dashboard.py
+++ b/notebooks/dashboard.py
@@ -64,7 +64,7 @@ def _(mo):
 
     project_selector = mo.ui.dropdown(
         options=_project_options,
-        value="__all__",
+        value="All Projects",
         label="Project scope",
     )
 


### PR DESCRIPTION
## Summary
- Fix `mo.ui.dropdown(value=...)` — marimo expects the label key ("All Projects"), not the mapped value ("__all__")

## Test plan
- [x] Marimo dashboard loads without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)