### PR TITLE
feat: mechanical enforcement for entire learning loop

### DIFF
--- a/.claude/hooks/enforce-buildlog-commit.sh
+++ b/.claude/hooks/enforce-buildlog-commit.sh
@@ -1,14 +1,21 @@
 #!/usr/bin/env bash
 # enforce-buildlog-commit.sh - Claude Code PreToolUse hook
-# Blocks bare `git commit` in Bash tool calls.
-# Forces agents to use buildlog_commit() which commits AND logs.
+#
+# Enforces TWO things:
+#   1. Blocks bare `git commit` → must use buildlog_commit()
+#   2. Blocks `gh pr create` without gauntlet-cleared marker
 #
 # Exceptions:
 #   - BUILDLOG_COMMIT=1 prefix (set by buildlog_commit() internally)
 #   - git commit --amend (fixup commits are fine)
-#   - git rebase (internally runs commit)
+#   - BUILDLOG_ENFORCE=0 (opt-out of all enforcement)
 
 set -euo pipefail
+
+# Global opt-out
+if [ "${BUILDLOG_ENFORCE:-1}" = "0" ]; then
+  exit 0
+fi
 
 INPUT=$(cat)
 
@@ -20,17 +27,14 @@ fi
 
 COMMAND=$(echo "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('tool_input',{}).get('command',''))" 2>/dev/null || echo "")
 
-# Check if it's a git commit command
+# --- Enforcement 1: Block bare git commit ---
 if printf '%s' "$COMMAND" | grep -qE '(^|&&|\||\;)\s*git\s+commit\b'; then
-  # Allow if BUILDLOG_COMMIT=1 is set (buildlog_commit() sets this)
   if printf '%s' "$COMMAND" | grep -qE 'BUILDLOG_COMMIT=1'; then
     exit 0
   fi
-  # Allow --amend (fixup commits)
   if printf '%s' "$COMMAND" | grep -qE 'git\s+commit\s+.*--amend'; then
     exit 0
   fi
-  # DENY
   cat <<'DENY_JSON'
 {
   "hookSpecificOutput": {
@@ -41,6 +45,24 @@ if printf '%s' "$COMMAND" | grep -qE '(^|&&|\||\;)\s*git\s+commit\b'; then
 }
 DENY_JSON
   exit 0
+fi
+
+# --- Enforcement 2: Block gh pr create without gauntlet ---
+if printf '%s' "$COMMAND" | grep -qE '(^|&&|\||\;)\s*gh\s+pr\s+create\b'; then
+  BUILDLOG_DIR="${CLAUDE_PROJECT_DIR:-.}/buildlog"
+  MARKER="$BUILDLOG_DIR/.buildlog/gauntlet_cleared"
+  if [ ! -f "$MARKER" ]; then
+    cat <<'DENY_JSON'
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "deny",
+    "permissionDecisionReason": "PR creation blocked. Run the gauntlet first: buildlog_gauntlet_loop(target=\"src/\"). The gauntlet must pass clean (or accept risk) before creating a PR."
+  }
+}
+DENY_JSON
+    exit 0
+  fi
 fi
 
 exit 0

--- a/.claude/hooks/post-tool-use.sh
+++ b/.claude/hooks/post-tool-use.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# post-tool-use.sh - Claude Code PostToolUse hook
+# Auto-fires reward signal after successful gh pr merge.
+
+set -euo pipefail
+
+BUILDLOG_DIR="${CLAUDE_PROJECT_DIR:-.}/buildlog"
+
+if [ ! -d "$BUILDLOG_DIR" ]; then
+  exit 0
+fi
+
+INPUT=$(cat)
+
+TOOL_NAME=$(echo "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('tool_name',''))" 2>/dev/null || echo "")
+
+if [ "$TOOL_NAME" != "Bash" ]; then
+  exit 0
+fi
+
+COMMAND=$(echo "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('tool_input',{}).get('command',''))" 2>/dev/null || echo "")
+
+if printf '%s' "$COMMAND" | grep -qE '(^|&&|\||\;)\s*gh\s+pr\s+merge\b'; then
+  buildlog reward accepted 2>/dev/null || true
+  rm -f "$BUILDLOG_DIR/.buildlog/gauntlet_cleared" 2>/dev/null || true
+fi
+
+exit 0

--- a/.claude/hooks/session-end.sh
+++ b/.claude/hooks/session-end.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# session-end.sh - Claude Code SessionEnd hook
+# Auto-ends the buildlog experiment session when Claude Code session ends.
+
+set -euo pipefail
+
+BUILDLOG_DIR="${CLAUDE_PROJECT_DIR:-.}/buildlog"
+
+if [ ! -d "$BUILDLOG_DIR" ]; then
+  exit 0
+fi
+
+buildlog experiment end 2>/dev/null || true

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# session-start.sh - Claude Code SessionStart hook
+# Auto-starts a buildlog experiment session when Claude Code starts.
+
+set -euo pipefail
+
+BUILDLOG_DIR="${CLAUDE_PROJECT_DIR:-.}/buildlog"
+
+if [ ! -d "$BUILDLOG_DIR" ]; then
+  exit 0
+fi
+
+buildlog experiment end 2>/dev/null || true
+buildlog experiment start 2>/dev/null || true

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,6 +10,48 @@
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/post-tool-use.sh"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/session-end.sh"
+          }
+        ]
+      }
+    ]
+  },
+  "rules": [
+    "Always define interfaces before implementations"
+  ],
+  "_buildlog": {
+    "last_updated": "2026-02-14T20:27:12.870884",
+    "promoted_skill_ids": [
+      "arch-b0efab23fe"
     ]
   }
 }

--- a/src/buildlog/core/operations.py
+++ b/src/buildlog/core/operations.py
@@ -1879,6 +1879,22 @@ def _get_active_session_path(buildlog_dir: Path) -> Path:
     return buildlog_dir / ".buildlog" / "active_session.json"
 
 
+def _get_gauntlet_marker_path(buildlog_dir: Path) -> Path:
+    """Get path to gauntlet-cleared marker file."""
+    return buildlog_dir / ".buildlog" / "gauntlet_cleared"
+
+
+def _write_gauntlet_marker(buildlog_dir: Path) -> None:
+    """Write marker file indicating gauntlet has passed/risk accepted.
+
+    This marker is checked by the PreToolUse hook before allowing
+    `gh pr create`. It is deleted after PR creation succeeds.
+    """
+    marker = _get_gauntlet_marker_path(buildlog_dir)
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    marker.write_text(datetime.now(timezone.utc).isoformat() + "\n")
+
+
 def _generate_session_id(now: datetime) -> str:
     """Generate a unique session ID."""
     # Include microseconds for uniqueness when sessions are created quickly
@@ -3006,6 +3022,29 @@ def gauntlet_process_issues(
     majors = [i for i in issues if i.get("severity") == "major"]
     minors = [i for i in issues if i.get("severity") in ("minor", "nitpick", None)]
 
+    # --- Auto-log mistakes for criticals and majors ---
+    # If the gauntlet caught it, the agent made a mistake. Period.
+    # This feeds the bandit without relying on the agent to self-report.
+    #
+    # Severity mapping: gauntlet → mistake (different valid sets)
+    _GAUNTLET_TO_MISTAKE_SEVERITY = {"critical": "critical", "major": "high"}
+    for issue in criticals + majors:
+        try:
+            gauntlet_sev = issue.get("severity", "major")
+            mistake_sev = _GAUNTLET_TO_MISTAKE_SEVERITY.get(gauntlet_sev, "high")
+            desc = issue.get("description", issue.get("rule_learned", "Unknown"))
+            location = issue.get("location", "")
+            log_mistake(
+                buildlog_dir,
+                error_class=f"gauntlet_{gauntlet_sev}",
+                description=f"[{location}] {desc}" if location else str(desc),
+                severity=mistake_sev,
+            )
+        except Exception:
+            logging.getLogger(__name__).debug(
+                "Auto-log mistake from gauntlet failed", exc_info=True
+            )
+
     # Persist learnings for this iteration
     learn_source = source or f"gauntlet:iteration-{iteration}"
     learn_result = learn_from_review(buildlog_dir, issues, learn_source)
@@ -3052,6 +3091,13 @@ def gauntlet_process_issues(
     else:
         action = "clean"
         message = f"Iteration {iteration}: All clear! No issues found."
+        # Write gauntlet-cleared marker for PR enforcement
+        try:
+            _write_gauntlet_marker(buildlog_dir)
+        except Exception:
+            logging.getLogger(__name__).debug(
+                "Failed to write gauntlet marker", exc_info=True
+            )
 
     return GauntletLoopResult(
         action=action,
@@ -3083,6 +3129,7 @@ def gauntlet_accept_risk(
     create_github_issues: bool = False,
     repo: str | None = None,
     cwd: str | None = None,
+    buildlog_dir: Path | None = None,
 ) -> GauntletAcceptRiskResult:
     """Accept risk for remaining issues, optionally creating GitHub issues.
 
@@ -3091,6 +3138,7 @@ def gauntlet_accept_risk(
         create_github_issues: Whether to create GitHub issues for tracking.
         repo: Repository for GitHub issues (uses current repo if None).
         cwd: Working directory for subprocess calls.
+        buildlog_dir: Path to buildlog directory (for gauntlet marker).
 
     Returns:
         GauntletAcceptRiskResult with created issue info.
@@ -3172,6 +3220,15 @@ def gauntlet_accept_risk(
             except FileNotFoundError:
                 error = "gh CLI not found. Install GitHub CLI to create issues."
                 break
+
+    # Write gauntlet-cleared marker for PR enforcement
+    if buildlog_dir is not None:
+        try:
+            _write_gauntlet_marker(buildlog_dir)
+        except Exception:
+            logging.getLogger(__name__).debug(
+                "Failed to write gauntlet marker in accept_risk", exc_info=True
+            )
 
     return GauntletAcceptRiskResult(
         accepted_issues=len(remaining_issues),
@@ -3758,8 +3815,42 @@ def commit(
     Returns:
         CommitResult with commit info and entry update status.
     """
+    import os
     import subprocess
     from datetime import date
+
+    # =========================================================================
+    # ENFORCEMENT: Block commit without active experiment session
+    # =========================================================================
+    # The entire learning loop depends on session-scoped data. Without an
+    # active session, the bandit never gets reward signals, and the system
+    # cannot prove convergence. This is the mechanical guarantee.
+    #
+    # Bypass: BUILDLOG_ENFORCE=0 (explicit opt-out)
+    # =========================================================================
+    enforce = os.environ.get("BUILDLOG_ENFORCE", "1") != "0"
+    if enforce and buildlog_dir.exists():
+        try:
+            backend, project_id = _get_storage(buildlog_dir)
+            session_data = backend.load_active_session(project_id)
+            if session_data is None:
+                return CommitResult(
+                    commit_hash="",
+                    commit_message="",
+                    files_changed=[],
+                    entry_path=None,
+                    entry_updated=False,
+                    message="",
+                    error=(
+                        "No active experiment session. "
+                        "Run `buildlog experiment start` first. "
+                        "The learning loop requires session-scoped tracking "
+                        "for bandit reward attribution. "
+                        "Set BUILDLOG_ENFORCE=0 to bypass."
+                    ),
+                )
+        except Exception:
+            pass  # Don't block commits if storage is broken
 
     run_kwargs: dict = {"cwd": cwd} if cwd else {}
 

--- a/src/buildlog/mcp/tools.py
+++ b/src/buildlog/mcp/tools.py
@@ -764,6 +764,7 @@ def buildlog_gauntlet_accept_risk(
         create_github_issues=create_github_issues,
         repo=repo,
         cwd=str(_project_root(buildlog_dir)) if buildlog_dir else None,
+        buildlog_dir=Path(buildlog_dir) if buildlog_dir else None,
     )
     return _ensure_message(asdict(result))
 

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -261,6 +261,11 @@ class TestBuildlogCommitEnvVar:
         buildlog_dir = tmp_path / "buildlog"
         buildlog_dir.mkdir()
 
+        # Session required for commit to proceed (learning loop enforcement)
+        from buildlog.core import start_session
+
+        start_session(buildlog_dir, error_class="test")
+
         with patch("subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(
                 returncode=1, stderr="not a git repo", stdout=""
@@ -269,7 +274,12 @@ class TestBuildlogCommitEnvVar:
 
             commit(buildlog_dir, ["-m", "test"])
 
-            # First call is 'git commit'
-            call_args = mock_run.call_args_list[0]
-            env = call_args.kwargs.get("env", {})
+            # Find the git commit call (may not be first due to session check)
+            git_commit_calls = [
+                c
+                for c in mock_run.call_args_list
+                if c.args and "git" in c.args[0] and "commit" in c.args[0]
+            ]
+            assert git_commit_calls, "No git commit subprocess call found"
+            env = git_commit_calls[0].kwargs.get("env", {})
             assert env.get("BUILDLOG_COMMIT") == "1"

--- a/tests/test_learning_loop_enforcement.py
+++ b/tests/test_learning_loop_enforcement.py
@@ -1,0 +1,440 @@
+"""Tests for learning loop enforcement: session gating, gauntlet markers, auto-mistakes."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+class TestCommitBlocksWithoutSession:
+    """commit() must block when no active experiment session exists."""
+
+    def test_commit_blocked_without_active_session(self, tmp_path: Path):
+        """commit() returns error when no session is active."""
+        from buildlog.core.operations import commit
+
+        buildlog_dir = tmp_path / "buildlog"
+        buildlog_dir.mkdir()
+        (buildlog_dir / ".buildlog").mkdir()
+
+        result = commit(buildlog_dir, git_args=["-m", "test"])
+        assert result.error is not None
+        assert "No active experiment session" in result.error
+
+    def test_commit_allowed_with_active_session(self, tmp_path: Path):
+        """commit() proceeds when a session is active."""
+        from buildlog.core import start_session
+        from buildlog.core.operations import commit
+
+        buildlog_dir = tmp_path / "buildlog"
+        buildlog_dir.mkdir()
+
+        start_session(buildlog_dir, error_class="test")
+
+        # Will fail at git commit (no repo), but should NOT fail at session check
+        result = commit(buildlog_dir, git_args=["-m", "test"])
+        # Error should be about git, not about session
+        if result.error:
+            assert "No active experiment session" not in result.error
+
+    def test_commit_bypass_with_enforce_zero(self, tmp_path: Path):
+        """BUILDLOG_ENFORCE=0 bypasses session check."""
+        from buildlog.core.operations import commit
+
+        buildlog_dir = tmp_path / "buildlog"
+        buildlog_dir.mkdir()
+        (buildlog_dir / ".buildlog").mkdir()
+
+        with patch.dict(os.environ, {"BUILDLOG_ENFORCE": "0"}):
+            result = commit(buildlog_dir, git_args=["-m", "test"])
+            # Should NOT block for session — might fail at git, that's fine
+            if result.error:
+                assert "No active experiment session" not in result.error
+
+    def test_commit_session_check_failure_does_not_block(self, tmp_path: Path):
+        """If storage is broken, don't block commits."""
+        from buildlog.core.operations import commit
+
+        buildlog_dir = tmp_path / "buildlog"
+        buildlog_dir.mkdir()
+
+        with patch(
+            "buildlog.core.operations._get_storage",
+            side_effect=RuntimeError("storage broken"),
+        ):
+            result = commit(buildlog_dir, git_args=["-m", "test"])
+            # Should NOT block — might fail at git, that's fine
+            if result.error:
+                assert "No active experiment session" not in result.error
+
+
+class TestGauntletMarker:
+    """gauntlet_process_issues() writes marker on clean, accept_risk writes marker."""
+
+    def test_clean_gauntlet_writes_marker(self, tmp_path: Path):
+        """Action=clean should write gauntlet_cleared marker."""
+        from buildlog.core.operations import (
+            _get_gauntlet_marker_path,
+            gauntlet_process_issues,
+        )
+
+        buildlog_dir = tmp_path / "buildlog"
+        buildlog_dir.mkdir()
+        (buildlog_dir / ".buildlog").mkdir()
+
+        # No issues = clean
+        result = gauntlet_process_issues(buildlog_dir, issues=[])
+        assert result.action == "clean"
+
+        marker = _get_gauntlet_marker_path(buildlog_dir)
+        assert marker.exists()
+
+    def test_critical_gauntlet_no_marker(self, tmp_path: Path):
+        """Action=fix_criticals should NOT write marker."""
+        from buildlog.core.operations import (
+            _get_gauntlet_marker_path,
+            gauntlet_process_issues,
+            start_session,
+        )
+
+        buildlog_dir = tmp_path / "buildlog"
+        buildlog_dir.mkdir()
+
+        # Need a session for log_mistake inside gauntlet
+        start_session(buildlog_dir, error_class="test")
+
+        result = gauntlet_process_issues(
+            buildlog_dir,
+            issues=[
+                {"severity": "critical", "description": "bad", "rule_learned": "x"}
+            ],
+        )
+        assert result.action == "fix_criticals"
+
+        marker = _get_gauntlet_marker_path(buildlog_dir)
+        assert not marker.exists()
+
+    def test_accept_risk_writes_marker(self, tmp_path: Path):
+        """gauntlet_accept_risk() should write marker."""
+        from buildlog.core.operations import (
+            _get_gauntlet_marker_path,
+            gauntlet_accept_risk,
+        )
+
+        buildlog_dir = tmp_path / "buildlog"
+        buildlog_dir.mkdir()
+        (buildlog_dir / ".buildlog").mkdir()
+
+        gauntlet_accept_risk(
+            remaining_issues=[{"severity": "minor", "description": "nit"}],
+            buildlog_dir=buildlog_dir,
+        )
+
+        marker = _get_gauntlet_marker_path(buildlog_dir)
+        assert marker.exists()
+
+    def test_accept_risk_without_buildlog_dir_no_crash(self):
+        """gauntlet_accept_risk() without buildlog_dir should not crash."""
+        from buildlog.core.operations import gauntlet_accept_risk
+
+        # No buildlog_dir = no marker, but no crash
+        result = gauntlet_accept_risk(
+            remaining_issues=[{"severity": "minor", "description": "nit"}],
+        )
+        assert result.accepted_issues == 1
+
+
+class TestGauntletAutoLogsMistakes:
+    """gauntlet_process_issues() auto-logs mistakes for criticals and majors."""
+
+    def test_critical_auto_logs_mistake(self, tmp_path: Path):
+        """Critical issue should auto-log a mistake."""
+        from buildlog.core import start_session
+        from buildlog.core.operations import gauntlet_process_issues
+        from buildlog.storage import get_backend
+
+        buildlog_dir = tmp_path / "buildlog"
+        buildlog_dir.mkdir()
+
+        start_session(buildlog_dir, error_class="test")
+
+        gauntlet_process_issues(
+            buildlog_dir,
+            issues=[
+                {
+                    "severity": "critical",
+                    "description": "SQL injection in query builder",
+                    "location": "src/db.py:42",
+                    "rule_learned": "Always parameterize queries",
+                }
+            ],
+        )
+
+        backend, project_id = get_backend(buildlog_dir, project_root=tmp_path)
+        mistakes = backend.load_events(project_id, "mistakes")
+        gauntlet_mistakes = [
+            m for m in mistakes if m.get("error_class", "").startswith("gauntlet_")
+        ]
+        assert len(gauntlet_mistakes) == 1
+        assert gauntlet_mistakes[0]["error_class"] == "gauntlet_critical"
+        assert "SQL injection" in gauntlet_mistakes[0]["description"]
+
+    def test_major_auto_logs_mistake(self, tmp_path: Path):
+        """Major issue should auto-log a mistake."""
+        from buildlog.core import start_session
+        from buildlog.core.operations import gauntlet_process_issues
+        from buildlog.storage import get_backend
+
+        buildlog_dir = tmp_path / "buildlog"
+        buildlog_dir.mkdir()
+
+        start_session(buildlog_dir, error_class="test")
+
+        gauntlet_process_issues(
+            buildlog_dir,
+            issues=[
+                {
+                    "severity": "major",
+                    "description": "Missing error handling",
+                    "rule_learned": "Handle errors",
+                }
+            ],
+        )
+
+        backend, project_id = get_backend(buildlog_dir, project_root=tmp_path)
+        mistakes = backend.load_events(project_id, "mistakes")
+        gauntlet_mistakes = [
+            m for m in mistakes if m.get("error_class", "").startswith("gauntlet_")
+        ]
+        assert len(gauntlet_mistakes) == 1
+        assert gauntlet_mistakes[0]["error_class"] == "gauntlet_major"
+
+    def test_minor_does_not_log_mistake(self, tmp_path: Path):
+        """Minor issues should NOT auto-log mistakes."""
+        from buildlog.core.operations import gauntlet_process_issues
+
+        buildlog_dir = tmp_path / "buildlog"
+        buildlog_dir.mkdir()
+        (buildlog_dir / ".buildlog").mkdir()
+
+        gauntlet_process_issues(
+            buildlog_dir,
+            issues=[
+                {
+                    "severity": "minor",
+                    "description": "Style nit",
+                    "rule_learned": "Use pathlib",
+                }
+            ],
+        )
+
+        from buildlog.storage import get_backend
+
+        backend, project_id = get_backend(buildlog_dir, project_root=tmp_path)
+        mistakes = backend.load_events(project_id, "mistakes")
+        gauntlet_mistakes = [
+            m for m in mistakes if m.get("error_class", "").startswith("gauntlet_")
+        ]
+        assert len(gauntlet_mistakes) == 0
+
+    def test_multiple_issues_log_multiple_mistakes(self, tmp_path: Path):
+        """Each critical/major should log its own mistake."""
+        from buildlog.core import start_session
+        from buildlog.core.operations import gauntlet_process_issues
+        from buildlog.storage import get_backend
+
+        buildlog_dir = tmp_path / "buildlog"
+        buildlog_dir.mkdir()
+
+        start_session(buildlog_dir, error_class="test")
+
+        gauntlet_process_issues(
+            buildlog_dir,
+            issues=[
+                {"severity": "critical", "description": "Bad 1", "rule_learned": "x"},
+                {"severity": "major", "description": "Bad 2", "rule_learned": "y"},
+                {"severity": "minor", "description": "Nit", "rule_learned": "z"},
+            ],
+        )
+
+        backend, project_id = get_backend(buildlog_dir, project_root=tmp_path)
+        mistakes = backend.load_events(project_id, "mistakes")
+        gauntlet_mistakes = [
+            m for m in mistakes if m.get("error_class", "").startswith("gauntlet_")
+        ]
+        # 1 critical + 1 major = 2 mistakes (minor excluded)
+        assert len(gauntlet_mistakes) == 2
+
+
+class TestHookScripts:
+    """Tests that hook scripts exist and are executable."""
+
+    HOOKS_DIR = Path(__file__).parent.parent / ".claude" / "hooks"
+
+    @pytest.mark.parametrize(
+        "script",
+        [
+            "enforce-buildlog-commit.sh",
+            "session-start.sh",
+            "session-end.sh",
+            "post-tool-use.sh",
+        ],
+    )
+    def test_hook_exists_and_executable(self, script: str):
+        hook = self.HOOKS_DIR / script
+        assert hook.exists(), f"{script} not found"
+        assert os.access(hook, os.X_OK), f"{script} not executable"
+
+    def test_pre_tool_use_denies_bare_git_commit(self):
+        """PreToolUse hook should deny bare git commit."""
+        hook = self.HOOKS_DIR / "enforce-buildlog-commit.sh"
+        input_json = json.dumps(
+            {"tool_name": "Bash", "tool_input": {"command": "git commit -m 'test'"}}
+        )
+        result = subprocess.run(
+            [str(hook)],
+            input=input_json,
+            capture_output=True,
+            text=True,
+            env={**os.environ, "BUILDLOG_ENFORCE": "1"},
+        )
+        assert result.returncode == 0
+        output = json.loads(result.stdout)
+        assert output["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+    def test_pre_tool_use_allows_buildlog_commit(self):
+        """PreToolUse hook should allow BUILDLOG_COMMIT=1."""
+        hook = self.HOOKS_DIR / "enforce-buildlog-commit.sh"
+        input_json = json.dumps(
+            {
+                "tool_name": "Bash",
+                "tool_input": {"command": "BUILDLOG_COMMIT=1 git commit -m 'test'"},
+            }
+        )
+        result = subprocess.run(
+            [str(hook)],
+            input=input_json,
+            capture_output=True,
+            text=True,
+            env={**os.environ, "BUILDLOG_ENFORCE": "1"},
+        )
+        assert result.returncode == 0
+        # Should NOT output deny JSON
+        assert "deny" not in result.stdout
+
+    def test_pre_tool_use_denies_pr_without_marker(self, tmp_path: Path):
+        """PreToolUse hook should deny gh pr create without gauntlet marker."""
+        hook = self.HOOKS_DIR / "enforce-buildlog-commit.sh"
+        input_json = json.dumps(
+            {
+                "tool_name": "Bash",
+                "tool_input": {"command": "gh pr create --title 'test'"},
+            }
+        )
+        # Point CLAUDE_PROJECT_DIR at tmp_path (no marker there)
+        env = {
+            **os.environ,
+            "BUILDLOG_ENFORCE": "1",
+            "CLAUDE_PROJECT_DIR": str(tmp_path),
+        }
+        # Create buildlog dir so the hook can find it
+        (tmp_path / "buildlog" / ".buildlog").mkdir(parents=True)
+
+        result = subprocess.run(
+            [str(hook)],
+            input=input_json,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        assert result.returncode == 0
+        output = json.loads(result.stdout)
+        assert output["hookSpecificOutput"]["permissionDecision"] == "deny"
+        assert (
+            "gauntlet"
+            in output["hookSpecificOutput"]["permissionDecisionReason"].lower()
+        )
+
+    def test_pre_tool_use_allows_pr_with_marker(self, tmp_path: Path):
+        """PreToolUse hook should allow gh pr create with gauntlet marker."""
+        hook = self.HOOKS_DIR / "enforce-buildlog-commit.sh"
+        input_json = json.dumps(
+            {
+                "tool_name": "Bash",
+                "tool_input": {"command": "gh pr create --title 'test'"},
+            }
+        )
+        # Create marker
+        marker_dir = tmp_path / "buildlog" / ".buildlog"
+        marker_dir.mkdir(parents=True)
+        (marker_dir / "gauntlet_cleared").write_text("2026-02-14T00:00:00Z\n")
+
+        env = {
+            **os.environ,
+            "BUILDLOG_ENFORCE": "1",
+            "CLAUDE_PROJECT_DIR": str(tmp_path),
+        }
+        result = subprocess.run(
+            [str(hook)],
+            input=input_json,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        assert result.returncode == 0
+        assert "deny" not in result.stdout
+
+    def test_enforce_zero_bypasses_all(self):
+        """BUILDLOG_ENFORCE=0 should bypass all enforcement."""
+        hook = self.HOOKS_DIR / "enforce-buildlog-commit.sh"
+        input_json = json.dumps(
+            {"tool_name": "Bash", "tool_input": {"command": "git commit -m 'test'"}}
+        )
+        result = subprocess.run(
+            [str(hook)],
+            input=input_json,
+            capture_output=True,
+            text=True,
+            env={**os.environ, "BUILDLOG_ENFORCE": "0"},
+        )
+        assert result.returncode == 0
+        assert "deny" not in result.stdout
+
+
+class TestSettingsJson:
+    """Verify .claude/settings.json has all required hook types."""
+
+    def test_settings_has_all_hook_types(self):
+        settings_path = Path(__file__).parent.parent / ".claude" / "settings.json"
+        settings = json.loads(settings_path.read_text())
+        hooks = settings["hooks"]
+        assert "PreToolUse" in hooks
+        assert "PostToolUse" in hooks
+        assert "SessionStart" in hooks
+        assert "SessionEnd" in hooks
+
+    def test_settings_hooks_point_to_existing_scripts(self):
+        settings_path = Path(__file__).parent.parent / ".claude" / "settings.json"
+        settings = json.loads(settings_path.read_text())
+        project_dir = settings_path.parent.parent
+
+        for hook_type, entries in settings["hooks"].items():
+            for entry in entries:
+                for hook in entry["hooks"]:
+                    cmd = hook["command"]
+                    # Replace $CLAUDE_PROJECT_DIR with actual path
+                    script_path = cmd.replace(
+                        '"$CLAUDE_PROJECT_DIR"', str(project_dir)
+                    ).replace("$CLAUDE_PROJECT_DIR", str(project_dir))
+                    # Extract the script path (may be quoted)
+                    script_path = script_path.strip('"').strip("'")
+                    assert Path(
+                        script_path
+                    ).exists(), (
+                        f"{hook_type} hook points to missing script: {script_path}"
+                    )

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -131,8 +131,9 @@ class TestBuildlogPromote:
 
         assert result["target"] == "settings_json"
 
-    def test_accepts_skill_target(self, tmp_path):
+    def test_accepts_skill_target(self, tmp_path, monkeypatch):
         """Should accept target='skill' for Anthropic Agent Skills format."""
+        monkeypatch.chdir(tmp_path)
         buildlog_dir = tmp_path / "buildlog"
         buildlog_dir.mkdir()
 
@@ -155,17 +156,12 @@ class TestBuildlogPromote:
         assert result["error"] is None
         assert skill_id in result["promoted_ids"]
 
-        # Verify SKILL.md was created
+        # Verify SKILL.md was created (promote writes to CWD/.claude/)
         skill_file = Path(".claude/skills/buildlog-learned/SKILL.md")
         assert skill_file.exists()
         content = skill_file.read_text()
         assert "---\n" in content  # YAML frontmatter
         assert "name: buildlog-learned" in content
-
-        # Cleanup
-        import shutil
-
-        shutil.rmtree(".claude", ignore_errors=True)
 
 
 class TestBuildlogReject:

--- a/tests/test_p0_commit.py
+++ b/tests/test_p0_commit.py
@@ -1,5 +1,6 @@
 """Exhaustive tests for the commit core operation and MCP tool."""
 
+import os
 import subprocess
 from pathlib import Path
 from unittest.mock import patch
@@ -7,6 +8,16 @@ from unittest.mock import patch
 import pytest
 
 from buildlog.core.operations import CommitResult, _resolve_entry_path_core, commit
+
+# Disable session enforcement for these tests — commit functionality is the SUT,
+# not the learning loop. Enforcement is tested in test_learning_loop_enforcement.py.
+pytestmark = pytest.mark.usefixtures("_disable_commit_enforcement")
+
+
+@pytest.fixture(autouse=True)
+def _disable_commit_enforcement(monkeypatch):
+    """Bypass session check so commit tests exercise git logic, not enforcement."""
+    monkeypatch.setenv("BUILDLOG_ENFORCE", "0")
 
 
 class TestResolveEntryPathCore:

--- a/tests/test_rule_attribution.py
+++ b/tests/test_rule_attribution.py
@@ -456,11 +456,16 @@ class TestGauntletProcessIssuesCitations:
                 iteration=1,
                 valid_rule_ids={"valid:rule:0"},
             )
-            mock_log.assert_called_once()
-            call_kwargs = mock_log.call_args
-            assert call_kwargs[1]["error_class"] == "citation_hallucination"
-            assert "hallucinated:rule:99" in call_kwargs[1]["description"]
-            assert call_kwargs[1]["severity"] == "minor"
+            # Called twice: once for citation hallucination, once for auto-mistake (major issue)
+            assert mock_log.call_count == 2
+            # First call: citation hallucination
+            hallucination_call = mock_log.call_args_list[0]
+            assert hallucination_call[1]["error_class"] == "citation_hallucination"
+            assert "hallucinated:rule:99" in hallucination_call[1]["description"]
+            assert hallucination_call[1]["severity"] == "minor"
+            # Second call: auto-logged gauntlet mistake
+            gauntlet_call = mock_log.call_args_list[1]
+            assert gauntlet_call[1]["error_class"] == "gauntlet_major"
 
 
 class TestGauntletProcessIssuesBanditCredit:


### PR DESCRIPTION
## Summary
- **Session gating**: `commit()` blocks without active experiment session (bypass: `BUILDLOG_ENFORCE=0`)
- **Gauntlet→PR gate**: PreToolUse hook blocks `gh pr create` without gauntlet-cleared marker file; marker written on clean gauntlet or accepted risk, deleted after merge
- **Auto-mistake logging**: `gauntlet_process_issues()` auto-logs criticals/majors as mistakes with severity mapping (critical→critical, major→high), feeding the bandit without agent self-reporting
- **Auto-reward on merge**: PostToolUse hook fires `buildlog reward accepted` after `gh pr merge`
- **Session lifecycle hooks**: SessionStart/SessionEnd hooks auto-start/end experiment sessions

## Bug fixes
- `tests/test_mcp_tools.py` had `shutil.rmtree(".claude")` with RELATIVE PATH — nuked the real project `.claude/` directory during test runs. Fixed with `monkeypatch.chdir(tmp_path)`.
- Severity mapping between gauntlet (`critical/major`) and mistake system (`critical/high`) — `major` was silently caught as invalid

## Test plan
- [x] 23 new tests in `test_learning_loop_enforcement.py` covering all enforcement paths
- [x] Full suite: 1481 passed, 3 skipped
- [x] Gauntlet review: 0 criticals, 0 majors, 2 minors accepted as risk (private fn import in tests, constant in fn body)

🤖 Generated with [Claude Code](https://claude.com/claude-code)