### PR TITLE
fix: learning loop reward signal — select_k + dedup

### DIFF
--- a/src/buildlog/core/operations.py
+++ b/src/buildlog/core/operations.py
@@ -2405,26 +2405,28 @@ def end_session(
     except Exception:
         pass  # Never break end_session()
 
-    # --- Auto-reward: close the feedback loop automatically ---
-    # Without this, the bandit never learns because manual log_reward()
-    # calls are forgotten ~100% of the time.  Outcome logic:
-    #   - 0 repeated mistakes -> "accepted" (rules worked)
-    #   - any repeated mistakes -> "revision" (rules partially failed)
-    #
-    # IMPORTANT: Pass rules_active explicitly. The active session was
-    # already deleted above (line ~2032), so log_reward() can't look
-    # it up. Without explicit rules, the bandit never updates.
-    auto_outcome = "accepted" if repeated == 0 else "revision"
+    # --- Auto-reward: FALLBACK only ---
+    # Only fire if no explicit reward was already logged for this session.
+    # The PostToolUse merge hook or manual log_reward() is the REAL signal.
+    # Auto-reward is the fallback for sessions without explicit feedback.
+    auto_outcome = "revision"  # default for session emission
     try:
-        log_reward(
-            buildlog_dir=buildlog_dir,
-            outcome=auto_outcome,  # type: ignore[arg-type]
-            rules_active=session.selected_rules,
-            error_class=session.error_class,
-            session_id=session.id,
-            source="auto:end_session",
-            notes=f"auto: {len(session_mistakes)} mistakes, {repeated} repeats",
+        raw_rewards = backend.load_events(project_id, "rewards")
+        session_reward = next(
+            (e for e in raw_rewards if e.get("session_id") == session.id), None
         )
+        auto_outcome = session_reward["outcome"] if session_reward else "revision"
+        if not session_reward:
+            log_reward(
+                buildlog_dir=buildlog_dir,
+                outcome="revision",
+                rules_active=session.selected_rules,
+                error_class=session.error_class,
+                session_id=session.id,
+                source="auto:end_session",
+                revision_distance=0.5,
+                notes=f"auto-fallback: {len(session_mistakes)} mistakes, {repeated} repeats",
+            )
     except Exception:
         pass  # Never break end_session()
 

--- a/src/buildlog/engine/experiments.py
+++ b/src/buildlog/engine/experiments.py
@@ -136,7 +136,7 @@ def start_session(
     buildlog_dir: Path,
     error_class: str | None = None,
     notes: str | None = None,
-    select_k: int = 3,
+    select_k: int = 0,
     available_rules: list[str] | None = None,
     seed_rule_ids: set[str] | None = None,
     seed_confidence_map: dict[str, float] | None = None,
@@ -153,6 +153,7 @@ def start_session(
         error_class: Error class being targeted (context for bandits).
         notes: Optional notes about the session.
         select_k: Number of rules to select via Thompson Sampling.
+                 Default 0 means auto-calculate: max(10, 10% of pool).
         available_rules: Explicit list of candidate rule IDs. If None,
             reads promoted IDs from .buildlog/promoted.json.
         seed_rule_ids: Set of rule IDs that get boosted priors.
@@ -168,6 +169,10 @@ def start_session(
         if available_rules is not None
         else _get_current_rules(buildlog_dir)
     )
+
+    # Auto-calculate k if not explicitly set (select_k <= 0 means auto)
+    if select_k <= 0:
+        select_k = max(10, len(current_rules) // 10) if current_rules else 10
 
     selected_rules: list[str] = []
 

--- a/src/buildlog/mcp/tools.py
+++ b/src/buildlog/mcp/tools.py
@@ -398,7 +398,7 @@ def buildlog_rewards(
 def buildlog_experiment_start(
     error_class: str | None = None,
     notes: str | None = None,
-    select_k: int = 3,
+    select_k: int = 0,
     buildlog_dir: str = DEFAULT_BUILDLOG_DIR,
 ) -> dict:
     """Start a tracked session with Thompson Sampling rule selection.

--- a/tests/test_enforcement.py
+++ b/tests/test_enforcement.py
@@ -12,8 +12,8 @@ import pytest
 class TestAutoRewardOnEndSession:
     """Tests that end_session() auto-fires a reward signal."""
 
-    def test_auto_reward_accepted_on_clean_session(self, tmp_path: Path):
-        """Clean session (no repeats) should auto-log accepted reward."""
+    def test_auto_reward_fallback_on_clean_session(self, tmp_path: Path):
+        """Clean session (no explicit reward) should auto-log neutral revision fallback."""
         from buildlog.core import end_session, start_session
 
         buildlog_dir = tmp_path / "buildlog"
@@ -22,17 +22,18 @@ class TestAutoRewardOnEndSession:
         start_session(buildlog_dir, error_class="test")
         end_session(buildlog_dir)
 
-        # Verify reward was logged
+        # Verify reward was logged as neutral fallback
         from buildlog.storage import get_backend
 
         backend, project_id = get_backend(buildlog_dir, project_root=tmp_path)
         rewards = backend.load_events(project_id, "rewards")
         auto_rewards = [r for r in rewards if r.get("source") == "auto:end_session"]
         assert len(auto_rewards) == 1
-        assert auto_rewards[0]["outcome"] == "accepted"
+        assert auto_rewards[0]["outcome"] == "revision"
+        assert auto_rewards[0]["revision_distance"] == 0.5
 
     def test_auto_reward_revision_on_repeated_mistakes(self, tmp_path: Path):
-        """Session with repeated mistakes should auto-log revision reward."""
+        """Both sessions get neutral revision fallback (no explicit reward for either)."""
         from buildlog.core import end_session, log_mistake, start_session
 
         buildlog_dir = tmp_path / "buildlog"
@@ -56,11 +57,11 @@ class TestAutoRewardOnEndSession:
         backend, project_id = get_backend(buildlog_dir, project_root=tmp_path)
         rewards = backend.load_events(project_id, "rewards")
         auto_rewards = [r for r in rewards if r.get("source") == "auto:end_session"]
-        # First session clean → accepted, second session with repeat → revision
+        # Both sessions get neutral revision fallback (no explicit reward)
         assert len(auto_rewards) == 2
-        outcomes = [r["outcome"] for r in auto_rewards]
-        assert "accepted" in outcomes
-        assert "revision" in outcomes
+        for r in auto_rewards:
+            assert r["outcome"] == "revision"
+            assert r["revision_distance"] == 0.5
 
     def test_auto_reward_does_not_break_end_session(self, tmp_path: Path):
         """If reward logging fails, end_session() should still succeed."""
@@ -117,6 +118,93 @@ class TestAutoRewardOnEndSession:
         auto_rewards = [r for r in rewards if r.get("source") == "auto:end_session"]
         assert len(auto_rewards) == 1
         assert auto_rewards[0]["session_id"] == start_result.session_id
+
+    def test_auto_reward_skipped_when_explicit_reward_exists(self, tmp_path: Path):
+        """If an explicit reward was logged during the session, skip auto-reward."""
+        from buildlog.core import end_session, log_reward, start_session
+
+        buildlog_dir = tmp_path / "buildlog"
+        buildlog_dir.mkdir()
+
+        start_session(buildlog_dir, error_class="test")
+        # Explicit reward during session
+        log_reward(buildlog_dir, outcome="accepted", source="hook:merge")
+        end_session(buildlog_dir)
+
+        from buildlog.storage import get_backend
+
+        backend, project_id = get_backend(buildlog_dir, project_root=tmp_path)
+        rewards = backend.load_events(project_id, "rewards")
+        # Only the explicit reward, no auto-reward
+        assert len(rewards) == 1
+        assert rewards[0]["source"] == "hook:merge"
+        auto_rewards = [r for r in rewards if r.get("source") == "auto:end_session"]
+        assert len(auto_rewards) == 0
+
+    def test_auto_reward_fires_when_no_explicit_reward(self, tmp_path: Path):
+        """When no explicit reward exists, auto-reward should fire."""
+        from buildlog.core import end_session, start_session
+
+        buildlog_dir = tmp_path / "buildlog"
+        buildlog_dir.mkdir()
+
+        start_session(buildlog_dir, error_class="test")
+        # No log_reward() call
+        end_session(buildlog_dir)
+
+        from buildlog.storage import get_backend
+
+        backend, project_id = get_backend(buildlog_dir, project_root=tmp_path)
+        rewards = backend.load_events(project_id, "rewards")
+        assert len(rewards) == 1
+        assert rewards[0]["source"] == "auto:end_session"
+
+    def test_dedup_matches_on_session_id(self, tmp_path: Path):
+        """Dedup should not bleed across sessions — session B gets auto-reward."""
+        from buildlog.core import end_session, log_reward, start_session
+
+        buildlog_dir = tmp_path / "buildlog"
+        buildlog_dir.mkdir()
+
+        # Session A: explicit reward → no auto-reward
+        start_session(buildlog_dir, error_class="test")
+        log_reward(buildlog_dir, outcome="accepted", source="hook:merge")
+        end_session(buildlog_dir)
+
+        # Session B: no explicit reward → auto-reward fires
+        start_session(buildlog_dir, error_class="test")
+        end_session(buildlog_dir)
+
+        from buildlog.storage import get_backend
+
+        backend, project_id = get_backend(buildlog_dir, project_root=tmp_path)
+        rewards = backend.load_events(project_id, "rewards")
+        auto_rewards = [r for r in rewards if r.get("source") == "auto:end_session"]
+        # Only session B got auto-reward
+        assert len(auto_rewards) == 1
+        explicit_rewards = [r for r in rewards if r.get("source") == "hook:merge"]
+        assert len(explicit_rewards) == 1
+
+    def test_auto_reward_fallback_uses_neutral_signal(self, tmp_path: Path):
+        """Auto-fallback must use revision with distance=0.5 → reward_value=0.5."""
+        from buildlog.core import end_session, start_session
+
+        buildlog_dir = tmp_path / "buildlog"
+        buildlog_dir.mkdir()
+
+        start_session(buildlog_dir, error_class="test")
+        end_session(buildlog_dir)
+
+        from buildlog.storage import get_backend
+
+        backend, project_id = get_backend(buildlog_dir, project_root=tmp_path)
+        rewards = backend.load_events(project_id, "rewards")
+        auto_rewards = [r for r in rewards if r.get("source") == "auto:end_session"]
+        assert len(auto_rewards) == 1
+        r = auto_rewards[0]
+        assert r["outcome"] == "revision"
+        assert r["revision_distance"] == 0.5
+        assert r["reward_value"] == 0.5
 
 
 class TestAutoMigrate:


### PR DESCRIPTION
## Summary

- **select_k auto-calculate**: `max(10, 10% of pool)` instead of hardcoded 3. 262 rules → 26/session → full coverage in ~10 sessions instead of ~87.
- **Dedup auto-reward**: `end_session()` checks if an explicit reward (merge hook / manual `log_reward()`) already exists for the session before firing auto-reward.
- **Neutral fallback**: Auto-reward uses `revision(distance=0.5)` → reward=0.5 (neutral) instead of inflated `accepted` (1.0). Only real signals (merge hook, manual feedback) produce reward=1.0.

## Test plan

- [x] `pytest tests/test_enforcement.py` — 17/17 pass (2 updated + 4 new)
- [x] `pytest tests/` — 1498 passed, 3 skipped, 0 failed
- [ ] Restart session: startup message shows `selected ~26/262 rules` (not 3)
- [ ] `buildlog_rewards(limit=5)` — no duplicate session_ids; auto-fallbacks show `revision` with `distance=0.5`

Closes #204

🤖 Generated with [Claude Code](https://claude.com/claude-code)