### PR TITLE
chore: bump version to 0.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.20.0] - 2026-03-07
+
+### Changed
+- Version bump to 0.20.0 (v0.19.0 release failed due to missing CHANGELOG at tag time).
+
 ## [0.19.0] - 2026-03-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Each gauntlet citation followed by a reward acceptance increments alpha in the B
 
 ## Current Limits
 
-This is v0.19, not the end state.
+This is v0.20, not the end state.
 
 - **Extraction quality is uneven.** Regex extractors miss nuance; LLM extractors are accurate but expensive. The middle ground is still being found.
 - **Single-agent only.** Multi-agent coordination (shared learning across agents) is designed but not implemented.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "buildlog"
-version = "0.19.0"
+version = "0.20.0"
 description = "Engineering notebook for AI-assisted development"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Bump version to 0.20.0 (v0.19.0 release failed due to missing CHANGELOG at tag time)
- All v0.19.0 changes already on main — this is just the version bump + CHANGELOG entry

## Test plan
- [x] pyproject.toml version updated
- [x] CHANGELOG entry added
- [x] README version reference updated
- [x] Gauntlet clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)