### PR TITLE
feat: consolidate accept-risk into single checklist issue (#219)

### DIFF
--- a/src/buildlog/core/operations.py
+++ b/src/buildlog/core/operations.py
@@ -2944,10 +2944,11 @@ class GauntletAcceptRiskResult:
 
     Attributes:
         accepted_issues: Number of issues accepted as risk
-        github_issues_created: Number of GitHub issues created (if enabled)
-        github_issue_urls: URLs of created GitHub issues
+        github_issues_created: Number of GitHub issues created (0 or 1)
+        github_issue_urls: URLs of created GitHub issues (0 or 1 element)
         message: Human-readable summary
         error: Error message if operation failed
+        checklist_items: Number of checklist items in the consolidated issue
     """
 
     accepted_issues: int
@@ -2955,6 +2956,7 @@ class GauntletAcceptRiskResult:
     github_issue_urls: list[str]
     message: str
     error: str | None = None
+    checklist_items: int = 0
 
 
 def gauntlet_process_issues(
@@ -3197,21 +3199,188 @@ def _sanitize_for_gh(text: str, max_len: int = 256) -> str:
     return sanitized.strip()
 
 
+# Label colours used by _ensure_gauntlet_labels
+_SEVERITY_LABEL_COLORS: dict[str, str] = {
+    "critical": "d73a4a",
+    "major": "e99d42",
+    "minor": "fbca04",
+    "nitpick": "cccccc",
+}
+
+_ACCEPTED_RISK_LABEL = "gauntlet/accepted-risk"
+_ACCEPTED_RISK_COLOR = "5319e7"
+
+
+def _ensure_gauntlet_labels(
+    severities: set[str],
+    repo: str | None = None,
+    cwd: str | None = None,
+) -> set[str]:
+    """Ensure severity + accepted-risk labels exist on the repo.
+
+    Pre-flights ``gh label list`` to discover existing labels, then creates
+    any missing ones.  Returns the set of labels that are safe to apply.
+    If ``gh`` is unavailable or any creation fails, proceeds silently —
+    never bails.
+    """
+    import subprocess
+
+    run_kwargs: dict = {"cwd": cwd} if cwd else {}
+    safe_labels: set[str] = set()
+
+    # Discover existing labels
+    existing: set[str] = set()
+    cmd_list = ["gh", "label", "list", "--json", "name", "--limit", "200"]
+    if repo:
+        cmd_list.extend(["--repo", repo])
+    try:
+        out = subprocess.run(
+            cmd_list,
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=15,
+            **run_kwargs,
+        )
+        for entry in json.loads(out.stdout):
+            existing.add(entry.get("name", ""))
+    except Exception:
+        # gh not available or API error — proceed without labels
+        return safe_labels
+
+    # Labels we want: each severity + accepted-risk
+    desired: dict[str, str] = {}
+    for sev in severities:
+        colour = _SEVERITY_LABEL_COLORS.get(sev)
+        if colour:
+            desired[sev] = colour
+    desired[_ACCEPTED_RISK_LABEL] = _ACCEPTED_RISK_COLOR
+
+    for label_name, colour in desired.items():
+        if label_name in existing:
+            safe_labels.add(label_name)
+            continue
+        cmd_create = [
+            "gh",
+            "label",
+            "create",
+            label_name,
+            "--description",
+            "Gauntlet severity",
+            "--color",
+            colour,
+        ]
+        if repo:
+            cmd_create.extend(["--repo", repo])
+        try:
+            subprocess.run(
+                cmd_create,
+                capture_output=True,
+                text=True,
+                check=True,
+                timeout=15,
+                **run_kwargs,
+            )
+            safe_labels.add(label_name)
+        except Exception:
+            # Label creation failed — skip this label, don't bail
+            pass
+
+    return safe_labels
+
+
+def _build_accept_risk_body(
+    grouped: dict[str, list[dict]],
+    iteration: int | None,
+    total: int,
+) -> str:
+    """Build the Markdown body for a consolidated accepted-risk issue."""
+    today = date.today().isoformat()
+
+    severity_counts = {sev: len(items) for sev, items in grouped.items() if items}
+    summary_parts = [f"{cnt} {sev}" for sev, cnt in severity_counts.items()]
+    severity_summary = ", ".join(summary_parts) if summary_parts else "none"
+
+    lines: list[str] = [
+        f"## Gauntlet Accepted Risk — {today}",
+        "",
+    ]
+    if iteration is not None:
+        lines.append(f"**Iteration:** {iteration} | **Total items:** {total}")
+    else:
+        lines.append(f"**Total items:** {total}")
+    lines.extend(
+        [
+            f"**Severity breakdown:** {severity_summary}",
+            "",
+            "---",
+        ]
+    )
+
+    for sev in ("critical", "major", "minor", "nitpick"):
+        items = grouped.get(sev, [])
+        if not items:
+            continue
+
+        lines.extend(["", f"### {sev.capitalize()} ({len(items)})", ""])
+
+        for item in items:
+            desc = _sanitize_for_gh(item.get("description", "Unknown"), 500)
+            location = _sanitize_for_gh(item.get("location", ""), 200)
+            rule = _sanitize_for_gh(item.get("rule_learned", ""), 300)
+            rules_consulted = item.get("rules_consulted", [])
+            rule_reasoning = item.get("rule_reasoning", {})
+
+            lines.append(f"- [ ] **{desc}**")
+            if location:
+                lines.append(f"  - Location: `{location}`")
+            if rule:
+                lines.append(f"  - Rule: {rule}")
+            if rules_consulted:
+                consulted_str = ", ".join(str(r) for r in rules_consulted)
+                lines.append(f"  - Rules consulted: {consulted_str}")
+            # Full reasoning only for critical/major
+            if sev in ("critical", "major") and rule_reasoning:
+                if isinstance(rule_reasoning, dict):
+                    reasoning_parts = [f"{k}: {v}" for k, v in rule_reasoning.items()]
+                    reasoning_str = "; ".join(reasoning_parts)
+                else:
+                    reasoning_str = str(rule_reasoning)
+                lines.append(f"  - Reasoning: {_sanitize_for_gh(reasoning_str, 500)}")
+
+    iter_suffix = f", iteration {iteration}" if iteration is not None else ""
+    lines.extend(
+        [
+            "",
+            "---",
+            f"_Created by buildlog gauntlet loop (accepted risk{iter_suffix})_",
+        ]
+    )
+
+    return "\n".join(lines)
+
+
 def gauntlet_accept_risk(
     remaining_issues: list[dict],
     create_github_issues: bool = False,
     repo: str | None = None,
     cwd: str | None = None,
     buildlog_dir: Path | None = None,
+    iteration: int | None = None,
 ) -> GauntletAcceptRiskResult:
-    """Accept risk for remaining issues, optionally creating GitHub issues.
+    """Accept risk for remaining issues, optionally creating a GitHub issue.
+
+    Creates a **single** consolidated GitHub issue with a task-list
+    checklist, grouped by severity (critical first).  Labels are
+    auto-created if missing.
 
     Args:
         remaining_issues: Issues being accepted as risk.
-        create_github_issues: Whether to create GitHub issues for tracking.
+        create_github_issues: Whether to create a GitHub issue for tracking.
         repo: Repository for GitHub issues (uses current repo if None).
         cwd: Working directory for subprocess calls.
         buildlog_dir: Path to buildlog directory (for gauntlet marker).
+        iteration: Gauntlet loop iteration number (for provenance).
 
     Returns:
         GauntletAcceptRiskResult with created issue info.
@@ -3220,79 +3389,84 @@ def gauntlet_accept_risk(
 
     github_urls: list[str] = []
     error: str | None = None
+    checklist_items = 0
 
     if create_github_issues and remaining_issues:
+        # Group issues by severity
+        severity_order = ("critical", "major", "minor", "nitpick")
+        grouped: dict[str, list[dict]] = {s: [] for s in severity_order}
         for issue in remaining_issues:
-            severity = issue.get("severity", "minor")
-            rule = issue.get("rule_learned", issue.get("description", "Unknown"))
-            description = issue.get("description", "")
-            location = issue.get("location", "")
+            sev = issue.get("severity", "minor")
+            if sev not in grouped:
+                sev = "minor"
+            grouped[sev].append(issue)
 
-            safe_severity = _sanitize_for_gh(str(severity), 20)
-            safe_rule = _sanitize_for_gh(str(rule), 200)
-            safe_description = _sanitize_for_gh(str(description), 1000)
-            safe_location = _sanitize_for_gh(str(location), 100)
+        checklist_items = len(remaining_issues)
 
-            # Build issue body
-            body_parts = [
-                f"**Severity:** {safe_severity}",
-                f"**Rule:** {safe_rule}",
-                "",
-                "## Description",
-                safe_description,
-            ]
-            if safe_location:
-                body_parts.extend(["", f"**Location:** `{safe_location}`"])
+        # Collect unique severities present
+        present_severities = {sev for sev, items in grouped.items() if items}
 
-            body_parts.extend(
-                [
-                    "",
-                    "---",
-                    "_Created by buildlog gauntlet loop (accepted risk)_",
-                ]
+        # Ensure labels exist (best-effort)
+        safe_labels = _ensure_gauntlet_labels(
+            present_severities,
+            repo=repo,
+            cwd=cwd,
+        )
+
+        # Build consolidated body
+        body = _build_accept_risk_body(grouped, iteration, len(remaining_issues))
+
+        # Build title with severity summary
+        sev_parts = []
+        for sev in severity_order:
+            cnt = len(grouped[sev])
+            if cnt:
+                sev_parts.append(f"{cnt} {sev}")
+        severity_summary = ", ".join(sev_parts)
+        title = (
+            f"[Gauntlet] {len(remaining_issues)} accepted-risk "
+            f"items ({severity_summary})"
+        )
+        # gh title max ~256
+        if len(title) > 250:
+            title = title[:247] + "..."
+
+        # Build label args
+        label_args: list[str] = []
+        for lbl in sorted(safe_labels):
+            label_args.extend(["--label", lbl])
+
+        cmd = [
+            "gh",
+            "issue",
+            "create",
+            "--title",
+            title,
+            "--body",
+            body,
+        ] + label_args
+        if repo:
+            cmd.extend(["--repo", repo])
+
+        run_kwargs: dict = {"cwd": cwd} if cwd else {}
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                check=True,
+                timeout=30,
+                **run_kwargs,
             )
-
-            body = "\n".join(body_parts)
-            title = f"[Gauntlet/{safe_severity}] {safe_rule[:60]}"
-
-            # Create GitHub issue
-            cmd = [
-                "gh",
-                "issue",
-                "create",
-                "--title",
-                title,
-                "--body",
-                body,
-                "--label",
-                severity,
-            ]
-            if repo:
-                cmd.extend(["--repo", repo])
-
-            run_kwargs: dict = {"cwd": cwd} if cwd else {}
-            try:
-                result = subprocess.run(
-                    cmd,
-                    capture_output=True,
-                    text=True,
-                    check=True,
-                    timeout=30,
-                    **run_kwargs,
-                )
-                # gh issue create outputs the URL
-                url = result.stdout.strip()
-                if url:
-                    github_urls.append(url)
-            except subprocess.CalledProcessError as e:
-                # Don't fail entirely, just note the error
-                error = f"Failed to create some GitHub issues: {e.stderr}"
-            except subprocess.TimeoutExpired:
-                error = "GitHub issue creation timed out (30s limit)."
-                break
-            except FileNotFoundError:
-                error = "gh CLI not found. Install GitHub CLI to create issues."
-                break
+            url = result.stdout.strip()
+            if url:
+                github_urls.append(url)
+        except subprocess.CalledProcessError as e:
+            error = f"Failed to create GitHub issue: {e.stderr}"
+        except subprocess.TimeoutExpired:
+            error = "GitHub issue creation timed out (30s limit)."
+        except FileNotFoundError:
+            error = "gh CLI not found. Install GitHub CLI to create issues."
 
     # Write gauntlet-cleared marker for PR enforcement
     if buildlog_dir is not None:
@@ -3309,11 +3483,13 @@ def gauntlet_accept_risk(
         github_issue_urls=github_urls,
         message=(
             f"Accepted {len(remaining_issues)} issues as risk. "
-            f"Created {len(github_urls)} GitHub issues."
+            f"Created {len(github_urls)} GitHub issue(s) with "
+            f"{checklist_items} checklist items."
             if create_github_issues
             else f"Accepted {len(remaining_issues)} issues as risk."
         ),
         error=error,
+        checklist_items=checklist_items,
     )
 
 

--- a/src/buildlog/mcp/tools.py
+++ b/src/buildlog/mcp/tools.py
@@ -739,33 +739,38 @@ def buildlog_gauntlet_accept_risk(
     create_github_issues: bool = False,
     repo: str | None = None,
     issues_file: str | None = None,
+    iteration: int | None = None,
     buildlog_dir: str = DEFAULT_BUILDLOG_DIR,
 ) -> dict:
     """Gauntlet returned "checkpoint_minors" or "checkpoint_majors" and user says "ship it"?
 
     Call this with the remaining_issues array from the last
     buildlog_gauntlet_issues() response. This is the exit ramp from the
-    gauntlet loop. Optionally set create_github_issues=True to file
-    tracking issues. Returns accepted_issues count, github_issue_urls list.
-    Response: ~300 tokens.
+    gauntlet loop. Optionally set create_github_issues=True to file a
+    **single consolidated GitHub issue** with a task-list checklist,
+    grouped by severity (critical first). Labels are auto-created on
+    the repo if they don't exist yet. Response: ~300 tokens.
 
     Provide remaining_issues inline OR via a JSON file path (not both).
 
     Args:
         remaining_issues: Issues being accepted as risk
-        create_github_issues: Whether to create GitHub issues for tracking
+        create_github_issues: Whether to create a GitHub issue for tracking.
+            Creates ONE issue with a checklist (not N separate issues).
         repo: Repository for GitHub issues (uses current repo if None)
         issues_file: Path to a JSON file containing the issues array.
             Mutually exclusive with 'remaining_issues'.
+        iteration: Gauntlet loop iteration number (for provenance in body).
 
     Returns:
-        Dict with accepted_issues, github_issues_created,
-        github_issue_urls, message
+        Dict with accepted_issues, github_issues_created (0 or 1),
+        github_issue_urls, checklist_items, message
 
     Example:
         buildlog_gauntlet_accept_risk(
             remaining_issues=[...],
-            create_github_issues=True
+            create_github_issues=True,
+            iteration=3,
         )
     """
     try:
@@ -779,6 +784,7 @@ def buildlog_gauntlet_accept_risk(
             "github_issue_urls": [],
             "message": "",
             "error": str(exc),
+            "checklist_items": 0,
         }
 
     from buildlog.core import gauntlet_accept_risk
@@ -789,6 +795,7 @@ def buildlog_gauntlet_accept_risk(
         repo=repo,
         cwd=str(_project_root(buildlog_dir)) if buildlog_dir else None,
         buildlog_dir=Path(buildlog_dir) if buildlog_dir else None,
+        iteration=iteration,
     )
     return _ensure_message(asdict(result))
 

--- a/tests/test_e2e_flows.py
+++ b/tests/test_e2e_flows.py
@@ -280,6 +280,7 @@ class TestFlowGauntletLoop:
         result = gauntlet_accept_risk(remaining_issues=remaining)
         assert isinstance(result, GauntletAcceptRiskResult)
         assert result.accepted_issues >= 1
+        assert result.checklist_items == 0  # no github issues created
 
     def test_learn_from_review_persists(self, tmp_path):
         """Learning from review issues should persist to disk."""

--- a/tests/test_gauntlet_loop.py
+++ b/tests/test_gauntlet_loop.py
@@ -216,6 +216,7 @@ class TestGauntletAcceptRisk:
         assert result.github_issues_created == 0
         assert len(result.github_issue_urls) == 0
         assert result.error is None
+        assert result.checklist_items == 0
 
     def test_accepts_empty_issues(self):
         """Should handle empty issues list."""
@@ -223,33 +224,101 @@ class TestGauntletAcceptRisk:
 
         assert result.accepted_issues == 0
         assert result.github_issues_created == 0
+        assert result.checklist_items == 0
 
+    @patch("buildlog.core.operations._ensure_gauntlet_labels")
     @patch("subprocess.run")
-    def test_creates_github_issues_when_enabled(self, mock_run):
-        """Should create GitHub issues when enabled."""
-        mock_run.return_value.stdout = "https://github.com/test/repo/issues/1\n"
+    def test_creates_single_consolidated_issue(self, mock_run, mock_labels):
+        """Should create ONE GitHub issue with checklist, not N issues."""
+        mock_labels.return_value = {"major", "minor", "gauntlet/accepted-risk"}
+        mock_run.return_value.stdout = "https://github.com/test/repo/issues/42\n"
         mock_run.return_value.returncode = 0
 
         issues = [
             {
                 "severity": "major",
-                "description": "Test issue",
-                "rule_learned": "Test rule",
+                "description": "Missing validation",
+                "rule_learned": "Validate inputs",
+                "location": "src/api.py:10",
+            },
+            {
+                "severity": "minor",
+                "description": "Unused import",
+                "rule_learned": "Clean imports",
+                "location": "src/utils.py:1",
+            },
+            {
+                "severity": "minor",
+                "description": "Long function",
+                "rule_learned": "Keep functions short",
             },
         ]
 
-        result = gauntlet_accept_risk(issues, create_github_issues=True)
+        result = gauntlet_accept_risk(issues, create_github_issues=True, iteration=3)
 
-        assert result.accepted_issues == 1
+        assert result.accepted_issues == 3
         assert result.github_issues_created == 1
+        assert result.checklist_items == 3
         assert len(result.github_issue_urls) == 1
         assert "github.com" in result.github_issue_urls[0]
 
+        # Only ONE gh issue create call (label list is mocked out)
+        assert mock_run.call_count == 1
+        call_args = mock_run.call_args[0][0]
+        assert call_args[0:3] == ["gh", "issue", "create"]
+
+        # Verify body contains checklist format
+        body_idx = call_args.index("--body") + 1
+        body = call_args[body_idx]
+        assert "- [ ]" in body
+        assert "Missing validation" in body
+        assert "Unused import" in body
+        assert "### Major" in body
+        assert "### Minor" in body
+        assert "iteration 3" in body.lower()
+
+    @patch("buildlog.core.operations._ensure_gauntlet_labels")
     @patch("subprocess.run")
-    def test_handles_gh_cli_error(self, mock_run):
+    def test_checklist_body_includes_provenance(self, mock_run, mock_labels):
+        """Body should include iteration, date, rule info."""
+        mock_labels.return_value = {"critical", "gauntlet/accepted-risk"}
+        mock_run.return_value.stdout = "https://github.com/test/repo/issues/1\n"
+        mock_run.return_value.returncode = 0
+
+        issues = [
+            {
+                "severity": "critical",
+                "description": "SQL injection",
+                "rule_learned": "Parameterize queries",
+                "location": "src/db.py:42",
+                "rules_consulted": ["R-001", "R-002"],
+                "rule_reasoning": {
+                    "R-001": "Direct string concat",
+                    "R-002": "User input",
+                },
+            },
+        ]
+
+        gauntlet_accept_risk(
+            issues,
+            create_github_issues=True,
+            iteration=5,
+        )
+
+        call_args = mock_run.call_args[0][0]
+        body_idx = call_args.index("--body") + 1
+        body = call_args[body_idx]
+        assert "Iteration:** 5" in body
+        assert "Rules consulted: R-001, R-002" in body
+        assert "Reasoning:" in body
+
+    @patch("buildlog.core.operations._ensure_gauntlet_labels")
+    @patch("subprocess.run")
+    def test_handles_gh_cli_error(self, mock_run, mock_labels):
         """Should handle gh CLI errors gracefully."""
         from subprocess import CalledProcessError
 
+        mock_labels.return_value = {"major", "gauntlet/accepted-risk"}
         mock_run.side_effect = CalledProcessError(1, "gh", stderr="Not logged in")
 
         issues = [
@@ -266,9 +335,11 @@ class TestGauntletAcceptRisk:
         assert result.github_issues_created == 0
         assert result.error is not None
 
+    @patch("buildlog.core.operations._ensure_gauntlet_labels")
     @patch("subprocess.run")
-    def test_handles_missing_gh_cli(self, mock_run):
+    def test_handles_missing_gh_cli(self, mock_run, mock_labels):
         """Should handle missing gh CLI gracefully."""
+        mock_labels.return_value = set()
         mock_run.side_effect = FileNotFoundError()
 
         issues = [
@@ -285,9 +356,11 @@ class TestGauntletAcceptRisk:
         assert result.github_issues_created == 0
         assert "not found" in result.error.lower()
 
+    @patch("buildlog.core.operations._ensure_gauntlet_labels")
     @patch("subprocess.run")
-    def test_uses_custom_repo(self, mock_run):
+    def test_uses_custom_repo(self, mock_run, mock_labels):
         """Should use custom repo when specified."""
+        mock_labels.return_value = {"minor", "gauntlet/accepted-risk"}
         mock_run.return_value.stdout = "https://github.com/custom/repo/issues/1\n"
         mock_run.return_value.returncode = 0
 
@@ -297,10 +370,86 @@ class TestGauntletAcceptRisk:
 
         gauntlet_accept_risk(issues, create_github_issues=True, repo="custom/repo")
 
-        # Check that --repo was passed
+        # Check that --repo was passed to gh issue create
         call_args = mock_run.call_args[0][0]
         assert "--repo" in call_args
         assert "custom/repo" in call_args
+
+    @patch("subprocess.run")
+    def test_label_auto_creation(self, mock_run):
+        """Should auto-create missing labels, skip existing ones."""
+        import json as _json
+
+        # First call: gh label list returns only "minor" exists
+        label_list_result = type(
+            "R",
+            (),
+            {
+                "stdout": _json.dumps([{"name": "minor"}]),
+                "returncode": 0,
+            },
+        )()
+        # Subsequent calls: label create, then issue create
+        issue_create_result = type(
+            "R",
+            (),
+            {
+                "stdout": "https://github.com/test/repo/issues/99\n",
+                "returncode": 0,
+            },
+        )()
+
+        mock_run.return_value = issue_create_result
+
+        # Make label list return our custom result, rest succeed
+        def side_effect(cmd, **kwargs):
+            if cmd[1] == "label" and cmd[2] == "list":
+                return label_list_result
+            return issue_create_result
+
+        mock_run.side_effect = side_effect
+
+        issues = [
+            {"severity": "minor", "description": "Test minor"},
+            {"severity": "major", "description": "Test major"},
+        ]
+
+        result = gauntlet_accept_risk(issues, create_github_issues=True)
+
+        assert result.github_issues_created == 1
+        # Should have called: label list, label create (major),
+        # label create (gauntlet/accepted-risk), issue create
+        assert mock_run.call_count >= 3
+
+    @patch("subprocess.run")
+    def test_label_fallback_when_gh_unavailable(self, mock_run):
+        """Should still create issue without labels if label ops fail."""
+        # _ensure_gauntlet_labels will fail (FileNotFoundError on label list)
+        # but issue create should still work
+        call_count = {"n": 0}
+
+        def side_effect(cmd, **kwargs):
+            call_count["n"] += 1
+            if cmd[1] == "label":
+                raise FileNotFoundError("gh not found")
+            result = type(
+                "R",
+                (),
+                {
+                    "stdout": "https://github.com/test/repo/issues/1\n",
+                    "returncode": 0,
+                },
+            )()
+            return result
+
+        mock_run.side_effect = side_effect
+
+        issues = [{"severity": "minor", "description": "Test"}]
+        result = gauntlet_accept_risk(issues, create_github_issues=True)
+
+        # Issue should be created even though labels failed
+        assert result.github_issues_created == 1
+        assert result.error is None
 
 
 class TestGauntletLoopIntegration:


### PR DESCRIPTION
## Summary

- Rewrites `gauntlet_accept_risk` to create **one consolidated GitHub issue** with task-list checklist grouped by severity, instead of N separate issues
- Adds `_ensure_gauntlet_labels` helper — auto-creates severity labels (with colors) + `gauntlet/accepted-risk` label; gracefully falls back if `gh` unavailable
- Adds `_build_accept_risk_body` helper — Markdown body with provenance (iteration, date, severity breakdown)
- Adds `iteration` param to `gauntlet_accept_risk` and MCP tool wrapper
- Adds `checklist_items` field to `GauntletAcceptRiskResult` dataclass

Closes #219

## Test plan
- [x] 9 accept_risk tests pass (7 rewritten + 2 new: label auto-creation, label fallback)
- [x] e2e flow test updated with `checklist_items` assertion
- [x] MCP server tool count test passes (35 tools)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>