### PR TITLE
docs: fix stale tool counts and missing MCP tools

### DIFF
--- a/docs/LEARNING-LOOP-E2E.md
+++ b/docs/LEARNING-LOOP-E2E.md
@@ -34,7 +34,7 @@ A user runs `buildlog init` in any project. This creates the `buildlog/` directo
 
 1. **CLI entry:** `src/buildlog/cli.py:61` — `init()` creates the `buildlog/` directory via copier template, ensures `.buildlog/seeds/` exists (`cli.py:116-118`), and calls `_init_mcp()` to register the MCP server (`cli.py:159-165`).
 
-2. **MCP server registration:** `src/buildlog/mcp/server.py:44` — `mcp = FastMCP("buildlog")` creates the server instance. Lines 47-100 register every tool via `mcp.tool()` decorator. The server exposes 28 tools covering the full lifecycle.
+2. **MCP server registration:** `src/buildlog/mcp/server.py:44` — `mcp = FastMCP("buildlog")` creates the server instance. Lines 47-100 register every tool via `mcp.tool()` decorator. The server exposes 36 tools covering the full lifecycle.
 
 3. **Always-on config:** The user's `~/.claude/CLAUDE.md` includes the `buildlog (Always On)` section. Every Claude Code session, in any project, has access to `buildlog_overview()`, `buildlog_commit()`, `buildlog_gauntlet_loop()`, and `buildlog_log_reward()`. The MCP server starts automatically.
 

--- a/docs/guides/mcp-integration.md
+++ b/docs/guides/mcp-integration.md
@@ -78,6 +78,7 @@ Claude Code reads `~/.claude.json` for global MCP servers. The local `.claude/se
 | `buildlog_experiment_metrics` | Get per-session or aggregate mistake rates |
 | `buildlog_experiment_report` | Generate comprehensive report |
 | `buildlog_bandit_status` | Get Thompson Sampling bandit state and rule rankings |
+| `buildlog_posterior_history` | Query Beta posterior snapshots and evolution over time for rules |
 | `buildlog_gauntlet_issues` | Process gauntlet issues and determine next action |
 | `buildlog_gauntlet_accept_risk` | Accept risk for remaining issues |
 | `buildlog_gauntlet_rules` | Load gauntlet reviewer rules |
@@ -85,6 +86,7 @@ Claude Code reads `~/.claude.json` for global MCP servers. The local `.claude/se
 | `buildlog_gauntlet_loop` | Full gauntlet loop configuration |
 | `buildlog_gauntlet_list_personas` | List available reviewer personas |
 | `buildlog_gauntlet_generate` | Generate gauntlet rules from source text |
+| `buildlog_gauntlet_rule_lookup` | Look up details of specific gauntlet rules by ID |
 | `buildlog_commit` | Git commit with auto buildlog entry update |
 | `buildlog_distill` | Extract patterns from buildlog entries |
 | `buildlog_skills` | Generate skill set from entries |

--- a/src/buildlog/constants.py
+++ b/src/buildlog/constants.py
@@ -92,7 +92,7 @@ After every significant commit or feature completion:
 4. `buildlog_experiment_metrics()` — per-session or aggregate stats
 5. `buildlog_experiment_report()` — comprehensive report
 
-### Tool Reference (34 tools)
+### Tool Reference (36 tools)
 
 **Commit & Entries:**
 - `buildlog_commit(message, git_args, slug, no_entry)` — git commit with auto buildlog entry
@@ -117,6 +117,7 @@ After every significant commit or feature completion:
 - `buildlog_gauntlet_accept_risk(remaining_issues)` — accept risk
 - `buildlog_gauntlet_list_personas()` — list available reviewer personas
 - `buildlog_gauntlet_generate(source_text, persona, dry_run)` — generate rules from source text
+- `buildlog_gauntlet_rule_lookup(rule_ids)` — look up details of specific gauntlet rules by ID
 
 **Review Learning:**
 - `buildlog_learn_from_review(issues, source)` — persist review learnings


### PR DESCRIPTION
## Summary
- Fix stale tool counts: 28→36 in LEARNING-LOOP-E2E.md, 34→36 in constants.py and llms-full.txt
- Add `buildlog_gauntlet_rule_lookup` and `buildlog_posterior_history` to MCP integration guide tools table
- Add `buildlog_gauntlet_rule_lookup` to constants.py tool reference

Closes #226

## Test plan
- [x] `buildlog mcp-test` confirms 36 tools
- [x] All tool count references now say 36
- [x] MCP guide tools table lists all 36 registered tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)