### PR TITLE
fix: README hero image absolute URL for PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 **Track what works. Prove it. Drop what doesn't.**
 
-<img src="assets/hero-banner-perfectdeliberate.png" alt="buildlog - A measurable learning loop for AI-assisted work" width="800"/>
+<img src="https://raw.githubusercontent.com/Peleke/buildlog-template/main/assets/hero-banner-perfectdeliberate.png" alt="buildlog - A measurable learning loop for AI-assisted work" width="800"/>
 
 > **RE: The art.** Yes, it's AI-generated. Yes, that's hypocritical for a project about rigor over vibes. Looking for an actual artist to pay for a real logo. If you know someone good, [open an issue](https://github.com/Peleke/buildlog-template/issues) or DM me. Budget exists.
 


### PR DESCRIPTION
## Summary
- Change hero banner `<img src>` from relative `assets/...` to absolute `https://raw.githubusercontent.com/...` so the image renders on PyPI.

## Test plan
- [x] Image still renders on GitHub (raw.githubusercontent URL works there too)
- [x] Will render on PyPI on next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)