### PR TITLE
fix: remove AI art disclaimer from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@
 
 <img src="https://raw.githubusercontent.com/Peleke/buildlog-template/main/assets/hero-banner-perfectdeliberate.png" alt="buildlog - A measurable learning loop for AI-assisted work" width="800"/>
 
-> **RE: The art.** Yes, it's AI-generated. Yes, that's hypocritical for a project about rigor over vibes. Looking for an actual artist to pay for a real logo. If you know someone good, [open an issue](https://github.com/Peleke/buildlog-template/issues) or DM me. Budget exists.
-
 **[Read the full documentation](https://peleke.github.io/buildlog-template/)** | **[Landing page](https://launchpad-git-buildlog-kwayet-fs-projects.vercel.app)**
 
 </div>


### PR DESCRIPTION
## Summary
- Remove the AI-generated art disclaimer blockquote from README

## Test plan
- [x] README renders clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)