### PR TITLE
fix: docs staleness audit — Python 3.11+, tool counts, render paths, bragi rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Each gauntlet citation followed by a reward acceptance increments alpha in the B
 
 ## Current Limits
 
-This is v0.20, not the end state.
+This is v0.22, not the end state.
 
 - **Extraction quality is uneven.** Regex extractors miss nuance; LLM extractors are accurate but expensive. The middle ground is still being found.
 - **Single-agent only.** Multi-agent coordination (shared learning across agents) is designed but not implemented.
@@ -151,7 +151,7 @@ pipx install buildlog         # or: uv tool install buildlog
 buildlog init-mcp --global -y # registers MCP + writes instructions to ~/.claude/CLAUDE.md
 ```
 
-That's it. Claude Code now has all 35 buildlog tools **and knows how to use them** in every project you open. No per-project setup needed.
+That's it. Claude Code now has all 36 buildlog tools **and knows how to use them** in every project you open. No per-project setup needed.
 
 The `--global` flag:
 - Registers the MCP server in `~/.claude.json` (Claude Code's global config)

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -50,7 +50,7 @@ RMR is not the only metric that matters. But it's one we can measure, and measur
 
 buildlog is building toward **contextual bandits** for automatic rule selection.
 
-### What Exists Today (v0.8)
+### What Exists Today
 
 | Component | Description | Status |
 |-----------|-------------|--------|
@@ -58,8 +58,9 @@ buildlog is building toward **contextual bandits** for automatic rule selection.
 | Confidence scoring | Frequency + recency based | Implemented |
 | Reward logging | Accept/reject/revision signals | Implemented |
 | Experiment tracking | Sessions, mistakes, RMR calculation | Implemented |
-| Review gauntlet | Curated persona-based code review | Implemented |
+| Review gauntlet | Curated persona-based code review (3 personas, 61 rules) | Implemented |
 | Thompson Sampling | Automatic rule selection via bandit | Implemented |
+| Posterior history | Per-rule convergence tracking over time | Implemented |
 
 ### Thompson Sampling Bandit
 
@@ -87,9 +88,9 @@ buildlog is building toward **contextual bandits** for automatic rule selection.
 | Confidence scoring | Frequency + recency decay | Implemented |
 | Semantic hashing | Mistake deduplication for RMR | Implemented |
 | Reward signals | Binary feedback infrastructure | Implemented |
-| Thompson Sampling | Rule selection under uncertainty | Implemented (v0.8) |
-| Beta-Bernoulli model | Posterior updates from binary reward | Implemented (v0.8) |
-| Contextual bandits | Context-dependent rule selection | Implemented (v0.8) |
+| Thompson Sampling | Rule selection under uncertainty | Implemented |
+| Beta-Bernoulli model | Posterior updates from binary reward | Implemented |
+| Contextual bandits | Context-dependent rule selection | Implemented |
 | Regret bounds | O(sqrt(KT log K)) theoretical guarantee | Follows from TS |
 
 We're not inventing new math. We're applying proven frameworks to a new domain.

--- a/docs/getting-started/hello-world.md
+++ b/docs/getting-started/hello-world.md
@@ -4,7 +4,7 @@ This walkthrough takes you from zero to a promoted rule in a real project. The c
 
 ## Prerequisites
 
-- Python 3.10+
+- Python 3.11+
 - A git repository (any project works)
 - Claude Code installed (for MCP integration)
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -2,7 +2,7 @@
 
 ## Requirements
 
-- Python 3.10+
+- Python 3.11+
 - A virtual environment (PEP 668 blocks system-level installs)
 
 ## Install

--- a/docs/guides/learning-backends.md
+++ b/docs/guides/learning-backends.md
@@ -142,7 +142,7 @@ The qortex backend is API-compatible with builtin. All MCP tools, CLI commands, 
 | Arm decay | Direct parameter manipulation | Via qortex's `ArmState` dataclass |
 | Credit propagation | None (standalone) | Shared across qortex consumers |
 | OTEL tracing | None | Available if qortex is configured for it |
-| Python requirement | 3.10+ | 3.11+ |
+| Python requirement | 3.11+ | 3.11+ |
 
 ### Context translation
 

--- a/docs/guides/review-gauntlet.md
+++ b/docs/guides/review-gauntlet.md
@@ -12,7 +12,7 @@ buildlog gauntlet list
 |---------|-------|-------|
 | **Security Karen** | OWASP Top 10, auth, injection, secrets | 13 |
 | **Test Terrorist** | Coverage, property-based, metamorphic, contracts | 21 |
-| **Bragi** | LLM prose pattern detection in markdown (em dashes, tricolons, performative honesty, etc.) | 9 |
+| **Bragi** | LLM prose pattern detection in markdown (em dashes, tricolons, performative honesty, etc.) | 27 |
 | **Ruthless Reviewer** | Code quality, FP principles | Coming soon |
 
 Each rule includes:

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -249,16 +249,16 @@ buildlog has optional dependency groups for features that need extra packages.
 
 | Extra | What it adds | Dependencies | Python |
 |-------|-------------|--------------|--------|
-| `embeddings` | Local sentence-transformers for semantic dedup | `sentence-transformers>=2.2.0` | 3.10+ |
-| `openai` | OpenAI embeddings for semantic dedup | `openai>=1.0.0` | 3.10+ |
-| `ollama` | Local LLM extraction via Ollama | `ollama>=0.4.0` | 3.10+ |
-| `anthropic` | Cloud LLM extraction via Anthropic Claude | `anthropic>=0.40.0` | 3.10+ |
-| `llm` | Both `ollama` and `anthropic` | both | 3.10+ |
+| `embeddings` | Local sentence-transformers for semantic dedup | `sentence-transformers>=2.2.0` | 3.11+ |
+| `openai` | OpenAI embeddings for semantic dedup | `openai>=1.0.0` | 3.11+ |
+| `ollama` | Local LLM extraction via Ollama | `ollama>=0.4.0` | 3.11+ |
+| `anthropic` | Cloud LLM extraction via Anthropic Claude | `anthropic>=0.40.0` | 3.11+ |
+| `llm` | Both `ollama` and `anthropic` | both | 3.11+ |
 | `qortex` | Pluggable learning backend with credit propagation | `qortex>=0.3.6` | 3.11+ |
-| `engine` | Documents the engine namespace (no extra deps) | none | 3.10+ |
-| `mcp` | Kept for backwards compat (MCP is now a default dep) | none | 3.10+ |
+| `engine` | Documents the engine namespace (no extra deps) | none | 3.11+ |
+| `mcp` | Kept for backwards compat (MCP is now a default dep) | none | 3.11+ |
 | `all` | Everything above | all of the above | 3.11+ |
-| `dev` | Development tools (pytest, black, mypy, etc.) | testing/linting stack | 3.10+ |
+| `dev` | Development tools (pytest, black, mypy, etc.) | testing/linting stack | 3.11+ |
 
 ### Base dependencies (always installed)
 
@@ -290,10 +290,10 @@ When promoting rules, the `--target` flag controls where rules are written:
 | Target | File | Agent |
 |--------|------|-------|
 | `claude_md` | `CLAUDE.md` | Claude Code |
-| `cursor` | `.cursorrules` | Cursor |
+| `cursor` | `.cursor/rules/buildlog-rules.mdc` | Cursor |
 | `copilot` | `.github/copilot-instructions.md` | GitHub Copilot |
-| `windsurf` | `.windsurfrules` | Windsurf |
-| `continue_dev` | `.continue/rules.md` | Continue.dev |
+| `windsurf` | `.windsurf/rules/buildlog-rules.md` | Windsurf |
+| `continue` | `.continue/rules/buildlog-rules.md` | Continue.dev |
 | `settings_json` | `.vscode/settings.json` | VS Code (generic) |
 | `skill` | Agent Skills format | Agent-agnostic |
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -52,7 +52,7 @@ This invokes the MCP server directly and lists all 36 tools. If it errors, the p
 
 **Fixes:**
 
-1. Check your Python version. buildlog requires 3.10+:
+1. Check your Python version. buildlog requires 3.11+:
    ```bash
    python3 --version
    ```

--- a/src/buildlog/__init__.py
+++ b/src/buildlog/__init__.py
@@ -1,3 +1,3 @@
 """buildlog - Engineering notebook for AI-assisted development."""
 
-__version__ = "0.21.1"
+__version__ = "0.22.0"


### PR DESCRIPTION
## Summary

- **Python 3.10+ → 3.11+** across 6 docs files (installation, hello-world, troubleshooting, configuration, learning-backends)
- **`__version__` synced** to 0.22.0 in `src/buildlog/__init__.py`
- **README**: "35 tools" → 36, "v0.20" → v0.22
- **Bragi rule count**: 9 → 27 in review-gauntlet.md
- **Render target paths** fixed in configuration.md (`.cursorrules` → `.cursor/rules/buildlog-rules.mdc`, etc.) to match actual renderer code
- **Stale v0.8 markers** removed from concepts.md, posterior history row added

## Test plan

- [ ] `buildlog mcp-test` still lists 36 tools
- [ ] `python -c "import buildlog; print(buildlog.__version__)"` prints `0.22.0`
- [ ] Docs site builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)