### PR TITLE
fix: decouple buildlog_commit from experiment session ceremony

### DIFF
--- a/src/buildlog/core/__init__.py
+++ b/src/buildlog/core/__init__.py
@@ -35,6 +35,7 @@ from buildlog.core.operations import (
     create_entry,
     diff,
     end_session,
+    ensure_session,
     find_skills_by_ids,
     gauntlet_accept_risk,
     gauntlet_generate,
@@ -97,6 +98,7 @@ __all__ = [
     "log_reward",
     "get_rewards",
     # Session tracking operations
+    "ensure_session",
     "start_session",
     "end_session",
     "log_mistake",

--- a/src/buildlog/core/operations.py
+++ b/src/buildlog/core/operations.py
@@ -2116,6 +2116,50 @@ def _find_similar_prior_mistake(
 # -----------------------------------------------------------------------------
 
 
+def ensure_session(buildlog_dir: Path) -> str:
+    """Ensure an active session exists, creating a lightweight one if needed.
+
+    If an active session already exists, return its ID (no-op).
+    If not, create a minimal session with no Thompson Sampling overhead:
+    just an ID, timestamp, and empty selected_rules.  This lets
+    ``commit()`` and other session-dependent code proceed without
+    requiring manual ``experiment start`` ceremony.
+
+    Lightweight sessions are distinguishable by their empty
+    ``selected_rules`` and ``notes="auto"`` marker.
+
+    Returns:
+        The session ID (existing or newly created).
+    """
+    try:
+        backend, project_id = _get_storage(buildlog_dir)
+        session_data = backend.load_active_session(project_id)
+        if session_data is not None:
+            return session_data["id"]
+    except Exception:
+        pass  # Storage broken — create a new session anyway
+
+    now = datetime.now(timezone.utc)
+    session_id = _generate_session_id(now)
+
+    session = Session(
+        id=session_id,
+        started_at=now,
+        rules_at_start=[],
+        selected_rules=[],
+        error_class=None,
+        notes="auto",
+    )
+
+    try:
+        backend, project_id = _get_storage(buildlog_dir)
+        backend.save_active_session(project_id, session.to_dict())  # type: ignore[arg-type]
+    except Exception:
+        pass  # Best-effort — don't block the caller
+
+    return session_id
+
+
 def start_session(
     buildlog_dir: Path,
     error_class: str | None = None,
@@ -4189,35 +4233,19 @@ def commit(
     from datetime import date
 
     # =========================================================================
-    # ENFORCEMENT: Block commit without active experiment session
+    # SESSION: Ensure an active session exists (auto-create if needed)
     # =========================================================================
-    # The entire learning loop depends on session-scoped data. Without an
-    # active session, the bandit never gets reward signals, and the system
-    # cannot prove convergence. This is the mechanical guarantee.
+    # The learning loop uses session-scoped data for RMR boundaries.
+    # Instead of blocking, we auto-create a lightweight session when none
+    # exists.  Full Thompson Sampling sessions are created by explicit
+    # ``experiment start`` or the session-start hook — this is the fallback.
     #
-    # Bypass: BUILDLOG_ENFORCE=0 (explicit opt-out)
+    # Skip entirely with BUILDLOG_ENFORCE=0.
     # =========================================================================
     enforce = os.environ.get("BUILDLOG_ENFORCE", "1") != "0"
     if enforce and buildlog_dir.exists():
         try:
-            backend, project_id = _get_storage(buildlog_dir)
-            session_data = backend.load_active_session(project_id)
-            if session_data is None:
-                return CommitResult(
-                    commit_hash="",
-                    commit_message="",
-                    files_changed=[],
-                    entry_path=None,
-                    entry_updated=False,
-                    message="",
-                    error=(
-                        "No active experiment session. "
-                        "Run `buildlog experiment start` first. "
-                        "The learning loop requires session-scoped tracking "
-                        "for bandit reward attribution. "
-                        "Set BUILDLOG_ENFORCE=0 to bypass."
-                    ),
-                )
+            ensure_session(buildlog_dir)
         except Exception:
             pass  # Don't block commits if storage is broken
 

--- a/tests/test_ensure_session.py
+++ b/tests/test_ensure_session.py
@@ -1,0 +1,212 @@
+"""Tests for ensure_session() and the decoupled commit flow.
+
+Proves that:
+1. ensure_session() creates a lightweight session when none exists
+2. ensure_session() is a no-op when a session already exists
+3. commit() no longer blocks without a session (auto-creates one)
+4. Lightweight sessions are distinguishable from full TS sessions
+5. The gauntlet + commit flow works end-to-end without manual ceremony
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from buildlog.core.operations import commit, ensure_session, start_session
+from buildlog.storage import get_backend
+
+
+class TestEnsureSession:
+    """ensure_session() creates or returns an active session."""
+
+    def test_creates_session_when_none_exists(self, tmp_path: Path):
+        """With no active session, ensure_session creates a lightweight one."""
+        buildlog_dir = tmp_path / "buildlog"
+        buildlog_dir.mkdir()
+
+        session_id = ensure_session(buildlog_dir)
+
+        assert session_id.startswith("session-")
+
+        # Verify it's stored
+        backend, project_id = get_backend(buildlog_dir, project_root=tmp_path)
+        session_data = backend.load_active_session(project_id)
+        assert session_data is not None
+        assert session_data["id"] == session_id
+
+    def test_returns_existing_session_id(self, tmp_path: Path):
+        """With an active session, ensure_session returns its ID (no-op)."""
+        buildlog_dir = tmp_path / "buildlog"
+        buildlog_dir.mkdir()
+
+        # Start a full session first
+        result = start_session(buildlog_dir, error_class="test")
+        original_id = result.session_id
+
+        # ensure_session should return the same ID
+        returned_id = ensure_session(buildlog_dir)
+        assert returned_id == original_id
+
+    def test_does_not_overwrite_full_session(self, tmp_path: Path):
+        """ensure_session must not replace a full TS session with a lightweight one."""
+        buildlog_dir = tmp_path / "buildlog"
+        buildlog_dir.mkdir()
+
+        result = start_session(buildlog_dir, error_class="test")
+        original_id = result.session_id
+
+        ensure_session(buildlog_dir)
+
+        backend, project_id = get_backend(buildlog_dir, project_root=tmp_path)
+        session_data = backend.load_active_session(project_id)
+        assert session_data["id"] == original_id
+
+    def test_lightweight_session_has_empty_selected_rules(self, tmp_path: Path):
+        """Lightweight sessions have selected_rules=[] and notes='auto'."""
+        buildlog_dir = tmp_path / "buildlog"
+        buildlog_dir.mkdir()
+
+        ensure_session(buildlog_dir)
+
+        backend, project_id = get_backend(buildlog_dir, project_root=tmp_path)
+        session_data = backend.load_active_session(project_id)
+
+        # Lightweight marker
+        assert session_data.get("notes") == "auto"
+        # No rules selected (no Thompson Sampling ran)
+        assert session_data.get("selected_rules", []) == []
+
+    def test_survives_broken_storage(self, tmp_path: Path):
+        """ensure_session doesn't crash if storage is broken."""
+        buildlog_dir = tmp_path / "buildlog"
+        buildlog_dir.mkdir()
+
+        with patch(
+            "buildlog.core.operations._get_storage",
+            side_effect=RuntimeError("storage broken"),
+        ):
+            # Should not raise
+            session_id = ensure_session(buildlog_dir)
+            assert session_id.startswith("session-")
+
+    def test_idempotent_multiple_calls(self, tmp_path: Path):
+        """Calling ensure_session twice returns the same session ID."""
+        buildlog_dir = tmp_path / "buildlog"
+        buildlog_dir.mkdir()
+
+        first = ensure_session(buildlog_dir)
+        second = ensure_session(buildlog_dir)
+        assert first == second
+
+
+class TestCommitWithoutSession:
+    """commit() no longer blocks without a session."""
+
+    def test_commit_no_longer_blocks_without_session(self, tmp_path: Path):
+        """commit() should NOT return 'No active experiment session' error."""
+        buildlog_dir = tmp_path / "buildlog"
+        buildlog_dir.mkdir()
+        (buildlog_dir / ".buildlog").mkdir()
+
+        result = commit(buildlog_dir, git_args=["-m", "test"])
+
+        # It may fail at git (no repo), but must NOT fail at session check
+        if result.error:
+            assert "No active experiment session" not in result.error
+
+    def test_commit_auto_creates_session(self, tmp_path: Path):
+        """commit() should auto-create a session via ensure_session."""
+        buildlog_dir = tmp_path / "buildlog"
+        buildlog_dir.mkdir()
+
+        # No session exists
+        backend, project_id = get_backend(buildlog_dir, project_root=tmp_path)
+        assert backend.load_active_session(project_id) is None
+
+        # commit() triggers ensure_session
+        commit(buildlog_dir, git_args=["-m", "test"])
+
+        # Now a session should exist
+        session_data = backend.load_active_session(project_id)
+        assert session_data is not None
+        assert session_data.get("notes") == "auto"
+
+    def test_commit_with_enforce_zero_skips_session(self, tmp_path: Path):
+        """BUILDLOG_ENFORCE=0 skips ensure_session entirely."""
+        buildlog_dir = tmp_path / "buildlog"
+        buildlog_dir.mkdir()
+
+        with patch.dict(os.environ, {"BUILDLOG_ENFORCE": "0"}):
+            commit(buildlog_dir, git_args=["-m", "test"])
+
+        backend, project_id = get_backend(buildlog_dir, project_root=tmp_path)
+        # No session created (enforcement was skipped)
+        assert backend.load_active_session(project_id) is None
+
+    def test_commit_preserves_existing_full_session(self, tmp_path: Path):
+        """commit() with an existing full session doesn't replace it."""
+        buildlog_dir = tmp_path / "buildlog"
+        buildlog_dir.mkdir()
+
+        result = start_session(buildlog_dir, error_class="test")
+        original_id = result.session_id
+
+        commit(buildlog_dir, git_args=["-m", "test"])
+
+        backend, project_id = get_backend(buildlog_dir, project_root=tmp_path)
+        session_data = backend.load_active_session(project_id)
+        assert session_data["id"] == original_id
+
+
+class TestNewUserFlow:
+    """End-to-end: a new user installs buildlog and commits without ceremony."""
+
+    def test_fresh_install_commit_works(self, tmp_path: Path):
+        """Simulates: pip install buildlog → init → commit (no experiment start)."""
+        buildlog_dir = tmp_path / "buildlog"
+        buildlog_dir.mkdir()
+
+        # User commits — no session started, no hooks, nothing
+        result = commit(buildlog_dir, git_args=["-m", "first commit"])
+
+        # Should fail at git (no repo), NOT at session enforcement
+        if result.error:
+            assert "No active experiment session" not in result.error
+            assert "experiment" not in result.error.lower()
+
+        # A lightweight session was auto-created
+        backend, project_id = get_backend(buildlog_dir, project_root=tmp_path)
+        session_data = backend.load_active_session(project_id)
+        assert session_data is not None
+        assert session_data.get("notes") == "auto"
+        assert session_data.get("selected_rules", []) == []
+
+    def test_gauntlet_then_commit_works_without_ceremony(self, tmp_path: Path):
+        """Simulates: gauntlet review → commit, no manual session start."""
+        from buildlog.core.operations import gauntlet_process_issues
+
+        buildlog_dir = tmp_path / "buildlog"
+        buildlog_dir.mkdir()
+        (buildlog_dir / ".buildlog").mkdir()
+
+        # Run gauntlet (works without session)
+        gauntlet_result = gauntlet_process_issues(
+            buildlog_dir,
+            issues=[
+                {
+                    "severity": "minor",
+                    "description": "Style nit",
+                    "rule_learned": "Use pathlib",
+                }
+            ],
+        )
+        assert gauntlet_result.action in ("clean", "checkpoint_minors")
+
+        # Now commit — should not block
+        result = commit(buildlog_dir, git_args=["-m", "fix: style nit"])
+        if result.error:
+            assert "No active experiment session" not in result.error

--- a/tests/test_learning_loop_enforcement.py
+++ b/tests/test_learning_loop_enforcement.py
@@ -14,17 +14,25 @@ import pytest
 class TestCommitBlocksWithoutSession:
     """commit() must block when no active experiment session exists."""
 
-    def test_commit_blocked_without_active_session(self, tmp_path: Path):
-        """commit() returns error when no session is active."""
+    def test_commit_auto_creates_session_without_active_session(self, tmp_path: Path):
+        """commit() auto-creates a lightweight session when none is active."""
         from buildlog.core.operations import commit
+        from buildlog.storage import get_backend
 
         buildlog_dir = tmp_path / "buildlog"
         buildlog_dir.mkdir()
         (buildlog_dir / ".buildlog").mkdir()
 
         result = commit(buildlog_dir, git_args=["-m", "test"])
-        assert result.error is not None
-        assert "No active experiment session" in result.error
+        # May fail at git, but must NOT fail at session check
+        if result.error:
+            assert "No active experiment session" not in result.error
+
+        # A lightweight session was auto-created
+        backend, project_id = get_backend(buildlog_dir, project_root=tmp_path)
+        session_data = backend.load_active_session(project_id)
+        assert session_data is not None
+        assert session_data.get("notes") == "auto"
 
     def test_commit_allowed_with_active_session(self, tmp_path: Path):
         """commit() proceeds when a session is active."""


### PR DESCRIPTION
## Summary

Closes #237 (Phase 1).

**The problem:** `buildlog_commit()` blocked with "No active experiment session" when no session was manually started. New users who `pip install buildlog` and try to commit hit this wall immediately. The session-start hook only exists in the maintainer's `.claude/hooks/` — nobody else has it.

**The fix:** Replace the blocking enforcement with `ensure_session()`, which auto-creates a lightweight session (ID + timestamp, no Thompson Sampling) when none exists. If a full TS session already exists (from explicit `experiment start` or hooks), it's a no-op.

### What changed

- **`ensure_session()`** — new function in `core/operations.py` that creates or returns a session
- **`commit()` enforcement block** — replaced "block and return error" with `ensure_session()` call
- **Lightweight sessions** — distinguishable by `notes="auto"` and `selected_rules=[]`
- **Gauntlet credits still work** — they don't depend on session's `selected_rules`

### What didn't change

- `BUILDLOG_ENFORCE=0` bypass still works
- Explicit `experiment start` still creates full TS sessions
- Storage broken → commit still proceeds (existing behavior)
- All existing gauntlet/marker/hook tests pass unchanged

## Test plan

35/35 tests pass:

- [x] `ensure_session()` creates session when none exists
- [x] `ensure_session()` returns existing session ID (no-op)
- [x] Does not overwrite full TS session with lightweight
- [x] Lightweight session has `notes="auto"`, empty `selected_rules`
- [x] Survives broken storage
- [x] Idempotent on repeated calls
- [x] `commit()` no longer blocks without session
- [x] `commit()` auto-creates session via `ensure_session()`
- [x] `BUILDLOG_ENFORCE=0` skips session creation entirely
- [x] Fresh install → commit works (new user flow)
- [x] Gauntlet → commit works without ceremony
- [x] All 23 existing enforcement tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)