### PR TITLE
chore: release v0.23.0 — ensure_session + docs audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.23.0] - 2026-03-14
+
+### Added
+- **`ensure_session()`** — auto-creates a lightweight session when none exists. `buildlog_commit()` no longer blocks without manual `experiment start`. New users can `pip install buildlog` and commit immediately.
+
+### Changed
+- **`commit()` enforcement block** replaced with `ensure_session()` call. The old behavior (block and return error) is gone. Lightweight sessions are distinguishable by `notes="auto"` and `selected_rules=[]`.
+
+### Fixed
+- **`__version__` synced** to 0.22.0 (was stuck at 0.21.1).
+- **Python 3.10+ → 3.11+** across 6 docs files to match `requires-python`.
+- **Render target paths** in configuration.md now match actual renderer code (`.cursorrules` → `.cursor/rules/buildlog-rules.mdc`, etc.).
+- **Bragi rule count** updated from 9 → 27 in review-gauntlet.md.
+- **README**: "35 tools" → 36, "v0.20" → v0.22.
+- **Stale v0.8 markers** removed from concepts.md.
+
 ## [0.22.0] - 2026-03-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@
 
 **Track what works. Prove it. Drop what doesn't.**
 
-<img src="https://raw.githubusercontent.com/Peleke/buildlog-template/main/assets/hero-banner-perfectdeliberate.png" alt="buildlog - A measurable learning loop for AI-assisted work" width="800"/>
-
 **[Read the full documentation](https://peleke.github.io/buildlog-template/)** | **[Landing page](https://launchpad-git-buildlog-kwayet-fs-projects.vercel.app)**
 
 </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "buildlog"
-version = "0.22.0"
+version = "0.23.0"
 description = "Engineering notebook for AI-assisted development"
 readme = "README.md"
 license = "MIT"

--- a/src/buildlog/__init__.py
+++ b/src/buildlog/__init__.py
@@ -1,3 +1,3 @@
 """buildlog - Engineering notebook for AI-assisted development."""
 
-__version__ = "0.22.0"
+__version__ = "0.23.0"


### PR DESCRIPTION
## Summary

Release v0.23.0. Key change: `buildlog_commit()` no longer blocks without a session.

### What's in this release
- **`ensure_session()`** — auto-creates lightweight sessions, removes the new-user blocker
- **Docs staleness audit** — Python 3.11+, tool counts, render paths, bragi rules, version refs
- **Hero image removed** from README
- **Version bump** to 0.23.0 across pyproject.toml, __init__.py, CHANGELOG

### After merge
Tag `v0.23.0` and push to trigger publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)