### PR TITLE
fix: publish workflow backtick escape in changelog notes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -164,6 +164,7 @@ jobs:
         run: |
           gh release create ${{ github.ref_name }} \
             --title "${{ github.ref_name }}" \
-            --notes "${{ steps.changelog.outputs.notes }}"
+            --notes "$RELEASE_NOTES"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_NOTES: ${{ steps.changelog.outputs.notes }}


### PR DESCRIPTION
## Summary

Backticks in CHANGELOG entries (e.g. `ensure_session()`) were being interpreted as bash command substitution when interpolated directly into the `gh release create --notes` argument. This broke the GitHub Release step on every release with code references in the changelog.

**Fix**: Pass notes via `RELEASE_NOTES` env var instead of direct `${{ }}` interpolation.

## Test plan

- [ ] Next release creates GitHub Release automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)