### PR TITLE
fix: clarify buildlog-template repo naming

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,6 +4,10 @@
 
 Capture what works. Measure whether it actually helped. Drop what didn't.
 
+
+!!! note "Why buildlog-template?"
+    This is buildlog, the canonical tool. The repo is named `buildlog-template` because it is designed to be forked directly into any project. The installable package is `buildlog`.
+
 ---
 
 buildlog extracts decision patterns from your AI-assisted work and uses a [Thompson Sampling contextual bandit](theory/index.md) to surface rules that reduce mistakes, then tracks whether they did. The feedback loop is statistical, not vibes-based.

--- a/src/buildlog/core/operations.py
+++ b/src/buildlog/core/operations.py
@@ -1240,13 +1240,17 @@ def log_reward(
         except Exception:
             pass
 
-    # Fall back to session data for session_id and error_class
-    session_data = backend.load_active_session(project_id)
-    if session_data is not None:
+    # Fall back to active session for session_id and error_class.
+    # auto_start=False: reward is a terminal event, don't create a session.
+    # Zombie sessions get upgraded so selected_rules are available.
+    try:
+        session = _require_active_session(buildlog_dir, auto_start=False)
         if session_id is None:
-            session_id = session_data.get("id")
+            session_id = session.id
         if error_class is None:
-            error_class = session_data.get("error_class")
+            error_class = session.error_class
+    except ValueError:
+        pass  # No active session — fine for log_reward
 
     event = RewardEvent(
         id=reward_id,
@@ -1650,9 +1654,8 @@ class Session:
             "ended_at": self.ended_at.isoformat() if self.ended_at else None,
             "rules_at_start": self.rules_at_start,
             "rules_at_end": self.rules_at_end,
+            "selected_rules": self.selected_rules,
         }
-        if self.selected_rules:
-            result["selected_rules"] = self.selected_rules
         if self.entry_file is not None:
             result["entry_file"] = self.entry_file
         if self.error_class is not None:
@@ -2116,48 +2119,92 @@ def _find_similar_prior_mistake(
 # -----------------------------------------------------------------------------
 
 
-def ensure_session(buildlog_dir: Path) -> str:
-    """Ensure an active session exists, creating a lightweight one if needed.
+def _require_active_session(
+    buildlog_dir: Path,
+    *,
+    auto_start: bool = True,
+) -> Session:
+    """Return the active session, upgrading zombies and auto-creating if needed.
 
-    If an active session already exists, return its ID (no-op).
-    If not, create a minimal session with no Thompson Sampling overhead:
-    just an ID, timestamp, and empty selected_rules.  This lets
-    ``commit()`` and other session-dependent code proceed without
-    requiring manual ``experiment start`` ceremony.
+    This is the SINGLE enforcement point for session-dependent operations.
+    It guarantees the returned Session has Thompson Sampling selection
+    (non-empty ``selected_rules`` when rules exist in the pool).
 
-    Lightweight sessions are distinguishable by their empty
-    ``selected_rules`` and ``notes="auto"`` marker.
+    Zombie detection: a session with ``notes="auto"`` and empty
+    ``selected_rules`` while the rule pool is non-empty is a zombie
+    created by the old ``ensure_session()``.  These are upgraded in-place
+    by running Thompson Sampling and updating storage.
+
+    Args:
+        buildlog_dir: Path to buildlog directory.
+        auto_start: If True (default), create a real session via
+            ``start_session()`` when none exists.  If False, raise
+            ``ValueError`` when no active session is found.
 
     Returns:
-        The session ID (existing or newly created).
+        The active Session object with ``selected_rules`` populated.
+
+    Raises:
+        ValueError: If ``auto_start=False`` and no active session exists.
     """
-    try:
-        backend, project_id = _get_storage(buildlog_dir)
-        session_data = backend.load_active_session(project_id)
-        if session_data is not None:
-            return session_data["id"]
-    except Exception:
-        pass  # Storage broken — create a new session anyway
+    backend, project_id = _get_storage(buildlog_dir)
+    session_data = backend.load_active_session(project_id)
 
-    now = datetime.now(timezone.utc)
-    session_id = _generate_session_id(now)
+    if session_data is not None:
+        session = Session.from_dict(session_data)  # type: ignore[arg-type]
 
-    session = Session(
-        id=session_id,
-        started_at=now,
-        rules_at_start=[],
-        selected_rules=[],
-        error_class=None,
-        notes="auto",
+        # --- Zombie upgrade path ---
+        # Detect: notes="auto" AND empty selected_rules AND rules exist
+        if session.notes == "auto" and not session.selected_rules:
+            current_rules = _get_current_rules(buildlog_dir)
+            if current_rules:
+                bandit = get_learning_backend(buildlog_dir)
+                seed_rule_ids, seed_confidence_map = _get_seed_rule_ids(buildlog_dir)
+                select_k = max(10, len(current_rules) // 10)
+
+                session.selected_rules = bandit.select(
+                    candidates=current_rules,
+                    context=session.error_class or "general",
+                    k=min(select_k, len(current_rules)),
+                    seed_rule_ids=seed_rule_ids,
+                    seed_confidence_map=seed_confidence_map or None,
+                )
+                session.rules_at_start = current_rules
+                session.notes = "auto:upgraded"
+
+                backend.save_active_session(
+                    project_id, session.to_dict()  # type: ignore[arg-type]
+                )
+
+        return session
+
+    # No active session
+    if not auto_start:
+        raise ValueError("No active session to end")
+
+    # Create a real session via start_session() — full Thompson Sampling
+    start_session(buildlog_dir, notes="auto:created")
+    # Re-load the freshly saved session
+    session_data = backend.load_active_session(project_id)
+    return Session.from_dict(session_data)  # type: ignore[arg-type]
+
+
+def ensure_session(buildlog_dir: Path) -> str:
+    """Deprecated: use ``_require_active_session()`` instead.
+
+    Kept for backward compatibility.  Returns session ID (string).
+    """
+    import warnings
+
+    warnings.warn(
+        "ensure_session() is deprecated.  Session-dependent operations now "
+        "use _require_active_session() internally, which guarantees "
+        "Thompson Sampling.",
+        DeprecationWarning,
+        stacklevel=2,
     )
-
-    try:
-        backend, project_id = _get_storage(buildlog_dir)
-        backend.save_active_session(project_id, session.to_dict())  # type: ignore[arg-type]
-    except Exception:
-        pass  # Best-effort — don't block the caller
-
-    return session_id
+    session = _require_active_session(buildlog_dir)
+    return session.id
 
 
 def start_session(
@@ -2410,12 +2457,10 @@ def end_session(
     """
     backend, project_id = _get_storage(buildlog_dir)
 
-    session_data = backend.load_active_session(project_id)
-    if session_data is None:
-        raise ValueError("No active session to end")
-
-    # Load active session
-    session = Session.from_dict(session_data)  # type: ignore[arg-type]
+    # auto_start=False: ending a nonexistent session is an error.
+    # Zombie sessions get upgraded (TS selection) before ending, so the
+    # auto-reward path at the bottom gets real selected_rules.
+    session = _require_active_session(buildlog_dir, auto_start=False)
 
     # Update session with end info
     now = datetime.now(timezone.utc)
@@ -2656,15 +2701,12 @@ def log_mistake(
 
     backend, project_id = _get_storage(buildlog_dir)
 
-    session_data = backend.load_active_session(project_id)
-    if session_data is not None:
-        session_id = session_data["id"]
-    else:
-        # No active session — use a synthetic ID so gauntlet auto-logging
-        # and standalone mistake logging work without session ceremony.
-        session_id = (
-            f"no-session-{datetime.now(timezone.utc).strftime('%Y%m%d-%H%M%S')}"
-        )
+    # Require a real session — auto-create via Thompson Sampling if needed.
+    # No more synthetic "no-session-*" IDs: every mistake must be attributed
+    # to a real session so the bandit gets negative feedback.
+    session = _require_active_session(buildlog_dir)
+    session_id = session.id
+    session_data = session.to_dict()
 
     now = datetime.now(timezone.utc)
     mistake_id = _generate_mistake_id(error_class, now)
@@ -2713,13 +2755,11 @@ def log_mistake(
     # Rules that repeatedly fail will become less likely to be selected.
     # =========================================================================
 
-    selected_rules = session_data.get("selected_rules", []) if session_data else []
+    selected_rules = session.selected_rules
     if selected_rules:
         bandit = get_learning_backend(buildlog_dir)
 
-        bandit_context = (
-            session_data.get("error_class") or "general" if session_data else "general"
-        )
+        bandit_context = session.error_class or "general"
 
         bandit.batch_update(
             rule_ids=selected_rules,
@@ -2737,7 +2777,7 @@ def log_mistake(
         gauntlet_map = _build_skill_to_gauntlet_map(buildlog_dir)
         manifest = _mistake_to_manifest(
             mistake=mistake,
-            session_data=session_data or {},
+            session_data=dict(session_data),
             selected_rules=selected_rules,
             project_id=project_id,
             registry=DEFAULT_REGISTRY,
@@ -4228,26 +4268,13 @@ def commit(
     Returns:
         CommitResult with commit info and entry update status.
     """
-    import os
     import subprocess
     from datetime import date
 
-    # =========================================================================
-    # SESSION: Ensure an active session exists (auto-create if needed)
-    # =========================================================================
-    # The learning loop uses session-scoped data for RMR boundaries.
-    # Instead of blocking, we auto-create a lightweight session when none
-    # exists.  Full Thompson Sampling sessions are created by explicit
-    # ``experiment start`` or the session-start hook — this is the fallback.
-    #
-    # Skip entirely with BUILDLOG_ENFORCE=0.
-    # =========================================================================
-    enforce = os.environ.get("BUILDLOG_ENFORCE", "1") != "0"
-    if enforce and buildlog_dir.exists():
-        try:
-            ensure_session(buildlog_dir)
-        except Exception:
-            pass  # Don't block commits if storage is broken
+    # Session lifecycle is managed by _require_active_session() inside
+    # session-dependent operations (log_mistake, log_reward, end_session)
+    # and explicitly via start_session() / experiment start.  commit() is
+    # a git operation — it does not create or require sessions.
 
     run_kwargs: dict = {"cwd": cwd} if cwd else {}
 

--- a/src/buildlog/engine/experiments.py
+++ b/src/buildlog/engine/experiments.py
@@ -31,6 +31,7 @@ from buildlog.core.operations import (
     Session,
     SessionMetrics,
     StartSessionResult,
+    _require_active_session,
 )
 from buildlog.core.operations import start_session as _core_start_session
 from buildlog.storage import StorageBackend, get_backend
@@ -187,11 +188,8 @@ def end_session(
     """
     backend, project_id = _get_storage(buildlog_dir)
 
-    session_data = backend.load_active_session(project_id)
-    if session_data is None:
-        raise ValueError("No active session to end")
-
-    session = Session.from_dict(session_data)  # type: ignore[arg-type]
+    # Zombie sessions get upgraded before ending (TS selection populated).
+    session = _require_active_session(buildlog_dir, auto_start=False)
 
     now = datetime.now(timezone.utc)
     session.ended_at = now
@@ -244,13 +242,9 @@ def log_mistake(
     """
     backend, project_id = _get_storage(buildlog_dir)
 
-    session_data = backend.load_active_session(project_id)
-    if session_data is None:
-        raise ValueError(
-            "No active session - start one with 'buildlog experiment start'"
-        )
-
-    session_id = session_data["id"]
+    # Auto-create session if none exists — guarantees Thompson Sampling.
+    session = _require_active_session(buildlog_dir)
+    session_id = session.id
 
     now = datetime.now(timezone.utc)
     mistake_id = _generate_mistake_id(error_class, now)
@@ -275,14 +269,14 @@ def log_mistake(
 
     backend.append_event(project_id, "mistakes", mistake.to_dict())  # type: ignore[arg-type]
 
-    selected_rules = session_data.get("selected_rules", [])
+    selected_rules = session.selected_rules
     if selected_rules:
         bandit = get_learning_backend(buildlog_dir)
-        context = session_data.get("error_class") or "general"
+        bandit_context = session.error_class or "general"
         bandit.batch_update(
             rule_ids=selected_rules,
             reward=0.0,
-            context=context,
+            context=bandit_context,
         )
 
     message = f"Logged mistake: {error_class}"
@@ -331,14 +325,17 @@ def log_reward(
 
     backend, project_id = _get_storage(buildlog_dir)
 
-    session_data = backend.load_active_session(project_id)
-    if session_data is not None:
+    # auto_start=False: reward is terminal, don't create a session.
+    try:
+        session = _require_active_session(buildlog_dir, auto_start=False)
         if session_id is None:
-            session_id = session_data.get("id")
+            session_id = session.id
         if rules_active is None:
-            rules_active = session_data.get("selected_rules", [])
+            rules_active = session.selected_rules
         if error_class is None:
-            error_class = session_data.get("error_class")
+            error_class = session.error_class
+    except ValueError:
+        pass  # No active session — fine for log_reward
 
     event = RewardEvent(
         id=reward_id,

--- a/tests/test_core_operations.py
+++ b/tests/test_core_operations.py
@@ -805,19 +805,21 @@ class TestLogMistake:
         assert result.was_repeat
         assert result.similar_prior is not None
 
-    def test_raises_error_if_no_active_session(self, tmp_path: Path):
-        """Should raise ValueError if no active session."""
+    def test_auto_creates_session_if_none_exists(self, tmp_path: Path):
+        """log_mistake auto-creates a session via _require_active_session."""
         from buildlog.core import log_mistake
 
         buildlog_dir = tmp_path / "buildlog"
         buildlog_dir.mkdir()
 
-        with pytest.raises(ValueError, match="No active session"):
-            log_mistake(
-                buildlog_dir,
-                error_class="missing_test",
-                description="Some mistake",
-            )
+        result = log_mistake(
+            buildlog_dir,
+            error_class="missing_test",
+            description="Some mistake",
+        )
+        # Should succeed and have a real session ID
+        assert result.session_id.startswith("session-")
+        assert not result.session_id.startswith("no-session-")
 
 
 class TestLogMistakeValidation:

--- a/tests/test_ensure_session.py
+++ b/tests/test_ensure_session.py
@@ -1,154 +1,234 @@
-"""Tests for ensure_session() and the decoupled commit flow.
+"""Tests for _require_active_session() and the decoupled commit flow.
 
 Proves that:
-1. ensure_session() creates a lightweight session when none exists
-2. ensure_session() is a no-op when a session already exists
-3. commit() no longer blocks without a session (auto-creates one)
-4. Lightweight sessions are distinguishable from full TS sessions
-5. The gauntlet + commit flow works end-to-end without manual ceremony
+1. _require_active_session() creates a real session with Thompson Sampling
+2. _require_active_session() returns existing session without modification
+3. _require_active_session(auto_start=False) raises when no session exists
+4. Zombie sessions (notes="auto", empty selected_rules) are upgraded in-place
+5. commit() no longer creates sessions (removed ensure_session call)
+6. ensure_session() is a deprecated wrapper
+7. Session.to_dict() always includes selected_rules
 """
 
 from __future__ import annotations
 
-import os
+import warnings
+from datetime import datetime, timezone
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 
-from buildlog.core.operations import commit, ensure_session, start_session
+from buildlog.core.operations import (
+    Session,
+    _require_active_session,
+    commit,
+    ensure_session,
+    start_session,
+)
 from buildlog.storage import get_backend
 
 
-class TestEnsureSession:
-    """ensure_session() creates or returns an active session."""
+def _seed_rules(buildlog_dir: Path, n: int = 3) -> list[str]:
+    """Insert gauntlet rules into the DB so Thompson Sampling has a pool."""
+    project_root = buildlog_dir.parent
+    backend, _pid = get_backend(buildlog_dir, project_root=project_root)
+    rules = []
+    for i in range(n):
+        rule_id = f"test_persona:{i:04d}"
+        rules.append(
+            {
+                "rule_id": rule_id,
+                "persona": "test_persona",
+                "rule": f"Test rule {i}",
+                "category": "test",
+                "context": "",
+                "antipattern": "",
+                "rationale": f"Rationale {i}",
+                "tags": "test",
+                "refs": "",
+                "provenance": "seed",
+                "version": 1,
+                "active": 1,
+            }
+        )
+    backend.save_gauntlet_rules_batch(rules)
+    return [r["rule_id"] for r in rules]
 
-    def test_creates_session_when_none_exists(self, tmp_path: Path):
-        """With no active session, ensure_session creates a lightweight one."""
+
+class TestRequireActiveSession:
+    """_require_active_session() creates or returns an active session with TS."""
+
+    def test_creates_real_session_when_none_exists(self, tmp_path: Path):
+        """With no active session, auto-creates one via start_session()."""
         buildlog_dir = tmp_path / "buildlog"
         buildlog_dir.mkdir()
 
-        session_id = ensure_session(buildlog_dir)
+        session = _require_active_session(buildlog_dir)
 
-        assert session_id.startswith("session-")
+        assert isinstance(session, Session)
+        assert session.id.startswith("session-")
+        # Real session — created via start_session, not a zombie
+        assert session.notes == "auto:created"
 
-        # Verify it's stored
-        backend, project_id = get_backend(buildlog_dir, project_root=tmp_path)
-        session_data = backend.load_active_session(project_id)
-        assert session_data is not None
-        assert session_data["id"] == session_id
-
-    def test_returns_existing_session_id(self, tmp_path: Path):
-        """With an active session, ensure_session returns its ID (no-op)."""
+    def test_returns_existing_session_unchanged(self, tmp_path: Path):
+        """With an active session, returns it without modification."""
         buildlog_dir = tmp_path / "buildlog"
         buildlog_dir.mkdir()
 
-        # Start a full session first
         result = start_session(buildlog_dir, error_class="test")
         original_id = result.session_id
 
-        # ensure_session should return the same ID
-        returned_id = ensure_session(buildlog_dir)
-        assert returned_id == original_id
+        session = _require_active_session(buildlog_dir)
+        assert session.id == original_id
 
-    def test_does_not_overwrite_full_session(self, tmp_path: Path):
-        """ensure_session must not replace a full TS session with a lightweight one."""
+    def test_auto_start_false_raises_when_no_session(self, tmp_path: Path):
+        """auto_start=False raises ValueError when no session exists."""
         buildlog_dir = tmp_path / "buildlog"
         buildlog_dir.mkdir()
 
-        result = start_session(buildlog_dir, error_class="test")
+        with pytest.raises(ValueError, match="No active session"):
+            _require_active_session(buildlog_dir, auto_start=False)
+
+    def test_upgrades_zombie_session(self, tmp_path: Path):
+        """Zombie session (notes='auto', empty selected_rules) gets upgraded."""
+        buildlog_dir = tmp_path / "buildlog"
+        buildlog_dir.mkdir()
+        _seed_rules(buildlog_dir, n=3)  # Need rules in pool for upgrade
+
+        # Manually create a zombie session (simulates old ensure_session)
+        backend, project_id = get_backend(buildlog_dir, project_root=tmp_path)
+        zombie = Session(
+            id="session-zombie-001",
+            started_at=datetime.now(timezone.utc),
+            rules_at_start=[],
+            selected_rules=[],
+            error_class=None,
+            notes="auto",
+        )
+        backend.save_active_session(project_id, zombie.to_dict())  # type: ignore[arg-type]
+
+        session = _require_active_session(buildlog_dir)
+
+        assert session.id == "session-zombie-001"  # Same session, upgraded
+        assert session.notes == "auto:upgraded"
+        assert len(session.selected_rules) > 0  # TS populated rules
+
+    def test_does_not_upgrade_non_zombie(self, tmp_path: Path):
+        """A real session with notes != 'auto' is NOT treated as zombie."""
+        buildlog_dir = tmp_path / "buildlog"
+        buildlog_dir.mkdir()
+
+        result = start_session(buildlog_dir, error_class="test", notes="real session")
         original_id = result.session_id
 
-        ensure_session(buildlog_dir)
+        session = _require_active_session(buildlog_dir)
+        assert session.id == original_id
+        assert session.notes == "real session"
 
+    def test_zombie_upgrade_idempotent(self, tmp_path: Path):
+        """Calling _require_active_session twice returns the same session."""
+        buildlog_dir = tmp_path / "buildlog"
+        buildlog_dir.mkdir()
+        _seed_rules(buildlog_dir, n=3)
+
+        # Create zombie
         backend, project_id = get_backend(buildlog_dir, project_root=tmp_path)
-        session_data = backend.load_active_session(project_id)
-        assert session_data["id"] == original_id
+        zombie = Session(
+            id="session-zombie-002",
+            started_at=datetime.now(timezone.utc),
+            rules_at_start=[],
+            selected_rules=[],
+            error_class=None,
+            notes="auto",
+        )
+        backend.save_active_session(project_id, zombie.to_dict())  # type: ignore[arg-type]
 
-    def test_lightweight_session_has_empty_selected_rules(self, tmp_path: Path):
-        """Lightweight sessions have selected_rules=[] and notes='auto'."""
+        first = _require_active_session(buildlog_dir)
+        second = _require_active_session(buildlog_dir)
+        assert first.id == second.id
+        # After first call: "auto:upgraded". Second call: not a zombie, returned as-is.
+        assert second.notes == "auto:upgraded"
+
+    def test_zombie_with_empty_pool_not_upgraded(self, tmp_path: Path):
+        """No rules in pool -> zombie left as-is (valid empty state)."""
         buildlog_dir = tmp_path / "buildlog"
         buildlog_dir.mkdir()
 
-        ensure_session(buildlog_dir)
-
         backend, project_id = get_backend(buildlog_dir, project_root=tmp_path)
-        session_data = backend.load_active_session(project_id)
+        zombie = Session(
+            id="session-zombie-003",
+            started_at=datetime.now(timezone.utc),
+            rules_at_start=[],
+            selected_rules=[],
+            error_class=None,
+            notes="auto",
+        )
+        backend.save_active_session(project_id, zombie.to_dict())  # type: ignore[arg-type]
 
-        # Lightweight marker
-        assert session_data.get("notes") == "auto"
-        # No rules selected (no Thompson Sampling ran)
-        assert session_data.get("selected_rules", []) == []
-
-    def test_survives_broken_storage(self, tmp_path: Path):
-        """ensure_session doesn't crash if storage is broken."""
-        buildlog_dir = tmp_path / "buildlog"
-        buildlog_dir.mkdir()
-
-        with patch(
-            "buildlog.core.operations._get_storage",
-            side_effect=RuntimeError("storage broken"),
-        ):
-            # Should not raise
-            session_id = ensure_session(buildlog_dir)
-            assert session_id.startswith("session-")
+        session = _require_active_session(buildlog_dir)
+        assert session.id == "session-zombie-003"
+        # No rules available, so selected_rules stays empty.
+        # notes stays "auto" because the upgrade path saw an empty pool.
+        assert session.selected_rules == []
 
     def test_idempotent_multiple_calls(self, tmp_path: Path):
-        """Calling ensure_session twice returns the same session ID."""
+        """Calling _require_active_session twice returns the same session."""
         buildlog_dir = tmp_path / "buildlog"
         buildlog_dir.mkdir()
 
-        first = ensure_session(buildlog_dir)
-        second = ensure_session(buildlog_dir)
-        assert first == second
+        first = _require_active_session(buildlog_dir)
+        second = _require_active_session(buildlog_dir)
+        assert first.id == second.id
 
 
-class TestCommitWithoutSession:
-    """commit() no longer blocks without a session."""
+class TestEnsureSessionDeprecated:
+    """ensure_session() is a deprecated wrapper."""
 
-    def test_commit_no_longer_blocks_without_session(self, tmp_path: Path):
-        """commit() should NOT return 'No active experiment session' error."""
-        buildlog_dir = tmp_path / "buildlog"
-        buildlog_dir.mkdir()
-        (buildlog_dir / ".buildlog").mkdir()
-
-        result = commit(buildlog_dir, git_args=["-m", "test"])
-
-        # It may fail at git (no repo), but must NOT fail at session check
-        if result.error:
-            assert "No active experiment session" not in result.error
-
-    def test_commit_auto_creates_session(self, tmp_path: Path):
-        """commit() should auto-create a session via ensure_session."""
+    def test_emits_deprecation_warning(self, tmp_path: Path):
+        """ensure_session() emits a DeprecationWarning."""
         buildlog_dir = tmp_path / "buildlog"
         buildlog_dir.mkdir()
 
-        # No session exists
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            session_id = ensure_session(buildlog_dir)
+
+        assert len(w) == 1
+        assert issubclass(w[0].category, DeprecationWarning)
+        assert "deprecated" in str(w[0].message).lower()
+        assert session_id.startswith("session-")
+
+    def test_returns_string_id(self, tmp_path: Path):
+        """ensure_session() returns a string session ID for backward compat."""
+        buildlog_dir = tmp_path / "buildlog"
+        buildlog_dir.mkdir()
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            session_id = ensure_session(buildlog_dir)
+
+        assert isinstance(session_id, str)
+        assert session_id.startswith("session-")
+
+
+class TestCommitDecoupled:
+    """commit() no longer creates sessions."""
+
+    def test_commit_does_not_create_session(self, tmp_path: Path):
+        """commit() should NOT create a session (ensure_session removed)."""
+        buildlog_dir = tmp_path / "buildlog"
+        buildlog_dir.mkdir()
+
         backend, project_id = get_backend(buildlog_dir, project_root=tmp_path)
         assert backend.load_active_session(project_id) is None
 
-        # commit() triggers ensure_session
         commit(buildlog_dir, git_args=["-m", "test"])
 
-        # Now a session should exist
-        session_data = backend.load_active_session(project_id)
-        assert session_data is not None
-        assert session_data.get("notes") == "auto"
-
-    def test_commit_with_enforce_zero_skips_session(self, tmp_path: Path):
-        """BUILDLOG_ENFORCE=0 skips ensure_session entirely."""
-        buildlog_dir = tmp_path / "buildlog"
-        buildlog_dir.mkdir()
-
-        with patch.dict(os.environ, {"BUILDLOG_ENFORCE": "0"}):
-            commit(buildlog_dir, git_args=["-m", "test"])
-
-        backend, project_id = get_backend(buildlog_dir, project_root=tmp_path)
-        # No session created (enforcement was skipped)
+        # No session should have been created
         assert backend.load_active_session(project_id) is None
 
-    def test_commit_preserves_existing_full_session(self, tmp_path: Path):
-        """commit() with an existing full session doesn't replace it."""
+    def test_commit_preserves_existing_session(self, tmp_path: Path):
+        """commit() with an existing session doesn't touch it."""
         buildlog_dir = tmp_path / "buildlog"
         buildlog_dir.mkdir()
 
@@ -161,52 +241,48 @@ class TestCommitWithoutSession:
         session_data = backend.load_active_session(project_id)
         assert session_data["id"] == original_id
 
-
-class TestNewUserFlow:
-    """End-to-end: a new user installs buildlog and commits without ceremony."""
-
-    def test_fresh_install_commit_works(self, tmp_path: Path):
-        """Simulates: pip install buildlog → init → commit (no experiment start)."""
+    def test_commit_no_session_error_is_git_error(self, tmp_path: Path):
+        """commit() without a session fails at git, not session enforcement."""
         buildlog_dir = tmp_path / "buildlog"
         buildlog_dir.mkdir()
 
-        # User commits — no session started, no hooks, nothing
-        result = commit(buildlog_dir, git_args=["-m", "first commit"])
-
-        # Should fail at git (no repo), NOT at session enforcement
+        result = commit(buildlog_dir, git_args=["-m", "test"])
         if result.error:
-            assert "No active experiment session" not in result.error
+            assert "session" not in result.error.lower()
             assert "experiment" not in result.error.lower()
 
-        # A lightweight session was auto-created
-        backend, project_id = get_backend(buildlog_dir, project_root=tmp_path)
-        session_data = backend.load_active_session(project_id)
-        assert session_data is not None
-        assert session_data.get("notes") == "auto"
-        assert session_data.get("selected_rules", []) == []
 
-    def test_gauntlet_then_commit_works_without_ceremony(self, tmp_path: Path):
-        """Simulates: gauntlet review → commit, no manual session start."""
-        from buildlog.core.operations import gauntlet_process_issues
+class TestSessionDictSerialization:
+    """Session.to_dict() always includes selected_rules."""
 
-        buildlog_dir = tmp_path / "buildlog"
-        buildlog_dir.mkdir()
-        (buildlog_dir / ".buildlog").mkdir()
-
-        # Run gauntlet (works without session)
-        gauntlet_result = gauntlet_process_issues(
-            buildlog_dir,
-            issues=[
-                {
-                    "severity": "minor",
-                    "description": "Style nit",
-                    "rule_learned": "Use pathlib",
-                }
-            ],
+    def test_empty_selected_rules_serialized(self):
+        """selected_rules=[] must appear in serialized dict, not be omitted."""
+        session = Session(
+            id="session-test-001",
+            started_at=datetime.now(timezone.utc),
+            selected_rules=[],
         )
-        assert gauntlet_result.action in ("clean", "checkpoint_minors")
+        d = session.to_dict()
+        assert "selected_rules" in d
+        assert d["selected_rules"] == []
 
-        # Now commit — should not block
-        result = commit(buildlog_dir, git_args=["-m", "fix: style nit"])
-        if result.error:
-            assert "No active experiment session" not in result.error
+    def test_populated_selected_rules_serialized(self):
+        """selected_rules with values are serialized normally."""
+        session = Session(
+            id="session-test-002",
+            started_at=datetime.now(timezone.utc),
+            selected_rules=["rule-a", "rule-b"],
+        )
+        d = session.to_dict()
+        assert d["selected_rules"] == ["rule-a", "rule-b"]
+
+    def test_roundtrip_preserves_empty_selected_rules(self):
+        """to_dict -> from_dict preserves empty list."""
+        session = Session(
+            id="session-test-003",
+            started_at=datetime.now(timezone.utc),
+            selected_rules=[],
+        )
+        d = session.to_dict()
+        restored = Session.from_dict(d)  # type: ignore[arg-type]
+        assert restored.selected_rules == []

--- a/tests/test_learning_loop_enforcement.py
+++ b/tests/test_learning_loop_enforcement.py
@@ -14,8 +14,8 @@ import pytest
 class TestCommitBlocksWithoutSession:
     """commit() must block when no active experiment session exists."""
 
-    def test_commit_auto_creates_session_without_active_session(self, tmp_path: Path):
-        """commit() auto-creates a lightweight session when none is active."""
+    def test_commit_does_not_create_session(self, tmp_path: Path):
+        """commit() no longer creates sessions — decoupled from session lifecycle."""
         from buildlog.core.operations import commit
         from buildlog.storage import get_backend
 
@@ -28,11 +28,10 @@ class TestCommitBlocksWithoutSession:
         if result.error:
             assert "No active experiment session" not in result.error
 
-        # A lightweight session was auto-created
+        # No session should be created — commit is a git op, not a learning op
         backend, project_id = get_backend(buildlog_dir, project_root=tmp_path)
         session_data = backend.load_active_session(project_id)
-        assert session_data is not None
-        assert session_data.get("notes") == "auto"
+        assert session_data is None
 
     def test_commit_allowed_with_active_session(self, tmp_path: Path):
         """commit() proceeds when a session is active."""
@@ -50,19 +49,22 @@ class TestCommitBlocksWithoutSession:
         if result.error:
             assert "No active experiment session" not in result.error
 
-    def test_commit_bypass_with_enforce_zero(self, tmp_path: Path):
-        """BUILDLOG_ENFORCE=0 bypasses session check."""
+    def test_commit_without_enforce_env_var(self, tmp_path: Path):
+        """BUILDLOG_ENFORCE is no longer used in commit (decoupled)."""
         from buildlog.core.operations import commit
+        from buildlog.storage import get_backend
 
         buildlog_dir = tmp_path / "buildlog"
         buildlog_dir.mkdir()
         (buildlog_dir / ".buildlog").mkdir()
 
-        with patch.dict(os.environ, {"BUILDLOG_ENFORCE": "0"}):
-            result = commit(buildlog_dir, git_args=["-m", "test"])
-            # Should NOT block for session — might fail at git, that's fine
-            if result.error:
-                assert "No active experiment session" not in result.error
+        # Even without BUILDLOG_ENFORCE, commit should not create sessions
+        result = commit(buildlog_dir, git_args=["-m", "test"])
+        if result.error:
+            assert "No active experiment session" not in result.error
+
+        backend, project_id = get_backend(buildlog_dir, project_root=tmp_path)
+        assert backend.load_active_session(project_id) is None
 
     def test_commit_session_check_failure_does_not_block(self, tmp_path: Path):
         """If storage is broken, don't block commits."""

--- a/tests/test_session_invariant_integration.py
+++ b/tests/test_session_invariant_integration.py
@@ -1,0 +1,313 @@
+"""Integration tests for the session invariant fix (GH #246).
+
+Cross-function chain tests. No mocks — real storage, real bandit.
+Proves that session-dependent operations create real sessions with
+Thompson Sampling, and that the bandit actually learns.
+"""
+
+from __future__ import annotations
+
+import ast
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from buildlog.core.learning import get_learning_backend
+from buildlog.core.operations import (
+    Session,
+    _require_active_session,
+    end_session,
+    gauntlet_process_issues,
+    get_experiment_report,
+    get_session_metrics,
+    log_mistake,
+    log_reward,
+    start_session,
+)
+from buildlog.storage import get_backend
+
+
+def _seed_rules(buildlog_dir: Path, n: int = 5) -> list[str]:
+    """Insert gauntlet rules into the DB so Thompson Sampling has a pool."""
+    project_root = buildlog_dir.parent
+    backend, _pid = get_backend(buildlog_dir, project_root=project_root)
+
+    rules = []
+    for i in range(n):
+        rule_id = f"test_persona:{i:04d}"
+        rules.append(
+            {
+                "rule_id": rule_id,
+                "persona": "test_persona",
+                "rule": f"Test rule number {i}",
+                "category": "test",
+                "context": "",
+                "antipattern": "",
+                "rationale": f"Rationale for rule {i}",
+                "tags": "test",
+                "refs": "",
+                "provenance": "seed",
+                "version": 1,
+                "active": 1,
+            }
+        )
+
+    backend.save_gauntlet_rules_batch(rules)
+    return [r["rule_id"] for r in rules]
+
+
+class TestGauntletToBanditUpdate:
+    """gauntlet_process_issues -> log_mistake -> bandit.batch_update."""
+
+    def test_gauntlet_critical_issues_update_bandit(self, tmp_path: Path):
+        """Critical gauntlet issues trigger negative bandit feedback."""
+        buildlog_dir = tmp_path / "buildlog"
+        buildlog_dir.mkdir()
+        _seed_rules(buildlog_dir, n=5)
+
+        # Start a real session so rules are selected
+        result = start_session(buildlog_dir)
+        assert len(result.selected_rules) > 0
+
+        bandit = get_learning_backend(buildlog_dir)
+
+        # Gauntlet finds critical issues -> auto-logs mistakes
+        gauntlet_process_issues(
+            buildlog_dir,
+            issues=[
+                {
+                    "severity": "critical",
+                    "description": "Missing input validation",
+                    "category": "security",
+                    "rule_learned": "Always validate input",
+                },
+            ],
+        )
+
+        stats_after = bandit.get_stats(context="general")
+        # The bandit should have been updated (beta increased for some arms)
+        assert stats_after, "Bandit should have stats after mistake logged"
+        # At least one arm should have observations
+        has_observations = any(
+            s.get("total_observations", 0) > 0 for s in stats_after.values()
+        )
+        assert has_observations, "At least one arm should have observations"
+
+
+class TestFullSessionLifecycle:
+    """start -> mistake -> reward -> end -> verify posteriors shifted."""
+
+    def test_complete_lifecycle_updates_bandit(self, tmp_path: Path):
+        """Full session lifecycle produces real bandit learning."""
+        buildlog_dir = tmp_path / "buildlog"
+        buildlog_dir.mkdir()
+        _seed_rules(buildlog_dir, n=5)
+
+        # Start — no error_class so context defaults to "general"
+        result = start_session(buildlog_dir)
+        session_id = result.session_id
+        assert len(result.selected_rules) > 0
+
+        # Mistake -> negative feedback (reward=0 for selected rules)
+        log_mistake(
+            buildlog_dir,
+            error_class="test_error",
+            description="Forgot to validate input",
+        )
+
+        # Reward -> positive feedback
+        log_reward(buildlog_dir, outcome="accepted")
+
+        bandit = get_learning_backend(buildlog_dir)
+        stats = bandit.get_stats(context="general")
+        # After mistake + reward, at least some arms should have observations
+        assert stats, "Bandit should have stats after full lifecycle"
+        has_observations = any(
+            s.get("total_observations", 0) > 0 for s in stats.values()
+        )
+        assert has_observations, "Bandit should have learned from the lifecycle"
+
+        # End session
+        end_result = end_session(buildlog_dir)
+        assert end_result.session_id == session_id
+        assert end_result.mistakes_logged >= 1
+
+
+class TestRewardAfterEndSession:
+    """end_session deletes the session, then calls log_reward internally."""
+
+    def test_auto_reward_uses_explicit_params(self, tmp_path: Path):
+        """Auto-reward at end_session works even though session is deleted."""
+        buildlog_dir = tmp_path / "buildlog"
+        buildlog_dir.mkdir()
+        _seed_rules(buildlog_dir, n=3)
+
+        start_session(buildlog_dir, error_class="test")
+
+        # End session — triggers auto-reward internally
+        result = end_session(buildlog_dir)
+        assert result.session_id.startswith("session-")
+        assert result.duration_minutes >= 0
+
+        # Verify reward was logged
+        backend, project_id = get_backend(buildlog_dir, project_root=tmp_path)
+        rewards = backend.load_events(project_id, "rewards")
+        assert len(rewards) >= 1
+
+
+class TestMultipleMistakesShareSession:
+    """Multiple mistakes in a gauntlet batch share one session."""
+
+    def test_no_phantom_sessions(self, tmp_path: Path):
+        """All mistakes from gauntlet share the same real session."""
+        buildlog_dir = tmp_path / "buildlog"
+        buildlog_dir.mkdir()
+        _seed_rules(buildlog_dir, n=5)
+
+        # No session exists — gauntlet will auto-create via log_mistake
+        gauntlet_process_issues(
+            buildlog_dir,
+            issues=[
+                {
+                    "severity": "critical",
+                    "description": f"Issue {i}",
+                    "category": "test",
+                    "rule_learned": f"Rule {i}",
+                }
+                for i in range(3)
+            ],
+        )
+
+        backend, project_id = get_backend(buildlog_dir, project_root=tmp_path)
+        mistakes = backend.load_events(project_id, "mistakes")
+
+        # All mistakes should share the same session_id
+        session_ids = {m["session_id"] for m in mistakes}
+        assert (
+            len(session_ids) == 1
+        ), f"Expected 1 session, got {len(session_ids)}: {session_ids}"
+
+        # And it should be a real session, not synthetic
+        session_id = session_ids.pop()
+        assert not session_id.startswith(
+            "no-session-"
+        ), f"Got synthetic session ID: {session_id}"
+
+
+class TestRMRNoPhantomSessions:
+    """RMR computation doesn't include phantom sessions."""
+
+    def test_rmr_computed_correctly(self, tmp_path: Path):
+        """Mistakes attributed to real session, visible in metrics."""
+        buildlog_dir = tmp_path / "buildlog"
+        buildlog_dir.mkdir()
+        _seed_rules(buildlog_dir, n=5)
+
+        result = start_session(buildlog_dir, error_class="test")
+        session_id = result.session_id
+
+        # Log some mistakes
+        log_mistake(buildlog_dir, error_class="test", description="Mistake 1")
+        log_mistake(buildlog_dir, error_class="test", description="Mistake 2")
+
+        # End session
+        end_session(buildlog_dir)
+
+        # Check metrics
+        metrics = get_session_metrics(buildlog_dir, session_id=session_id)
+        assert metrics.total_mistakes == 2
+        assert metrics.session_id == session_id
+
+
+class TestZombieUpgradeThenEndSession:
+    """Zombie upgrade before end_session produces correct metrics."""
+
+    def test_zombie_upgraded_then_ended(self, tmp_path: Path):
+        """Zombie gets upgraded, end_session sees real selected_rules."""
+        buildlog_dir = tmp_path / "buildlog"
+        buildlog_dir.mkdir()
+        _seed_rules(buildlog_dir, n=5)
+
+        # Create zombie
+        backend, project_id = get_backend(buildlog_dir, project_root=tmp_path)
+        zombie = Session(
+            id="session-zombie-end-test",
+            started_at=datetime.now(timezone.utc),
+            rules_at_start=[],
+            selected_rules=[],
+            error_class=None,
+            notes="auto",
+        )
+        backend.save_active_session(project_id, zombie.to_dict())  # type: ignore[arg-type]
+
+        # End session — should upgrade zombie first
+        result = end_session(buildlog_dir)
+        assert result.session_id == "session-zombie-end-test"
+
+        # Verify the session was saved with upgraded notes and selected_rules
+        sessions = backend.load_events(project_id, "sessions")
+        ended = [s for s in sessions if s["id"] == "session-zombie-end-test"]
+        assert len(ended) == 1
+        # Notes should reflect upgrade
+        assert "auto:upgraded" in (ended[0].get("notes") or "")
+
+
+class TestNoSyntheticIDsAnywhere:
+    """No operation produces synthetic no-session-* IDs."""
+
+    def test_log_mistake_without_session_creates_real_one(self, tmp_path: Path):
+        """log_mistake with no session auto-creates a real session."""
+        buildlog_dir = tmp_path / "buildlog"
+        buildlog_dir.mkdir()
+
+        result = log_mistake(
+            buildlog_dir,
+            error_class="test",
+            description="A mistake without prior session",
+        )
+
+        assert not result.session_id.startswith(
+            "no-session-"
+        ), f"Got synthetic ID: {result.session_id}"
+        assert result.session_id.startswith("session-")
+
+        # Session was auto-created
+        backend, project_id = get_backend(buildlog_dir, project_root=tmp_path)
+        session_data = backend.load_active_session(project_id)
+        assert session_data is not None
+
+
+class TestStructuralInvariant:
+    """No function in operations.py calls load_active_session directly
+    except _require_active_session and start_session."""
+
+    def test_no_direct_load_active_session_bypass(self):
+        """Grep-based test: verify enforcement point isn't bypassed."""
+        ops_path = (
+            Path(__file__).parent.parent / "src" / "buildlog" / "core" / "operations.py"
+        )
+        source = ops_path.read_text()
+        tree = ast.parse(source)
+
+        # Find all function definitions and their calls to load_active_session.
+        # get_overview is read-only (displays session info), not session-dependent.
+        allowed_callers = {"_require_active_session", "start_session", "get_overview"}
+        violations = []
+
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef):
+                func_name = node.name
+                for child in ast.walk(node):
+                    if (
+                        isinstance(child, ast.Attribute)
+                        and child.attr == "load_active_session"
+                        and func_name not in allowed_callers
+                    ):
+                        violations.append(
+                            f"{func_name}() calls load_active_session directly"
+                        )
+
+        assert (
+            violations == []
+        ), f"These functions bypass _require_active_session: {violations}"


### PR DESCRIPTION
Adds a note explaining that buildlog-template IS buildlog.